### PR TITLE
Allow for USWDS v2 and v3 defaults

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       [
+        develop,
         main,
       ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       [
+        develop,
         main,
       ]
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,68 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      [
+        main,
+      ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches:
+      [
+        main,
+      ]
+  schedule:
+    - cron: "0 21 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ["javascript"]
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,20 +1,6 @@
-/*
-* * * * * ==============================
-* * * * * ==============================
-* * * * * ==============================
-* * * * * ==============================
-========================================
-========================================
-========================================
-----------------------------------------
-USWDS SASS GULPFILE
-----------------------------------------
-*/
-
 const autoprefixer = require("autoprefixer");
 const csso = require("postcss-csso");
 const { src, dest, series, parallel, watch } = require("gulp");
-const pkg = require("../../uswds/package.json").version;
 const postcss = require("gulp-postcss");
 const replace = require("gulp-replace");
 const sass = require("gulp-sass")(require("sass"));
@@ -34,13 +20,32 @@ let settings = {
   compile: {
     paths: {
       src: {
-        uswds: "./node_modules/uswds/dist",
-        sass: "./node_modules/uswds/dist/scss",
-        theme: "./node_modules/uswds/dist/scss/theme",
-        fonts: "./node_modules/uswds/dist/fonts",
-        img: "./node_modules/uswds/dist/img",
-        js: "./node_modules/uswds/dist/js",
+        uswds: null,
+        sass: null,
+        theme: null,
+        fonts: null,
+        img: null,
+        js: null,
         projectSass: "./sass",
+        version: 2,
+        defaults: {
+          v2: {
+            uswds: "./node_modules/uswds/dist",
+            sass: "./node_modules/uswds/dist/scss",
+            theme: "./node_modules/uswds/dist/scss/theme",
+            fonts: "./node_modules/uswds/dist/fonts",
+            img: "./node_modules/uswds/dist/img",
+            js: "./node_modules/uswds/dist/js",    
+          },
+          v3: {
+            uswds: "./node_modules/@uswds",
+            sass: "./node_modules/@uswds/uswds/packages",
+            theme: "./node_modules/@uswds/uswds/dist/theme",
+            fonts: "./node_modules/@uswds/uswds/dist/fonts",
+            img: "./node_modules/@uswds/uswds/dist/img",
+            js: "./node_modules/@uswds/uswds/dist/js",
+          }
+        }
       },
       /**
        * ? project paths
@@ -70,6 +75,13 @@ let settings = {
 
 let paths = settings.compile.paths;
 
+let getSrcFrom = (key) => {
+  if (paths.src[key]) {
+    return paths.src[key];
+  }
+  return paths.src.defaults[`v${settings.version}`][key];
+}
+
 /*
 ----------------------------------------
 TASKS
@@ -81,22 +93,23 @@ TASKS
 USWDS specific tasks
 ----------------------------------------
 */
+
 const copy = {
   theme() {
-    log(colorBlue, `Copying USWDS theme files to ${paths.dist.theme}`);
-    return src(`${paths.src.theme}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.theme));
+    log(colorBlue, `Copy USWDS theme files: ${getSrcFrom("theme")} → ${paths.dist.theme}`);
+    return src(`${getSrcFrom("theme")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.theme));
   },
   fonts() {
-    log(colorBlue, `Copying USWDS fonts to ${paths.dist.fonts}`);
-    return src(`${paths.src.fonts}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.fonts));
+    log(colorBlue, `Copy USWDS fonts: ${getSrcFrom("fonts")} → ${paths.dist.fonts}`);
+    return src(`${getSrcFrom("fonts")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.fonts));
   },
   images() {
-    log(colorBlue, `Copying USWDS images to ${paths.dist.img}`);
-    return src(`${paths.src.img}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.img));
+    log(colorBlue, `Copy USWDS images: ${getSrcFrom("img")} →  ${paths.dist.img}`);
+    return src(`${getSrcFrom("img")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.img));
   },
   js() {
-    log(colorBlue, `Copying USWDS JavaScript to ${paths.dist.js}`);
-    return src(`${paths.src.js}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.js));
+    log(colorBlue, `Copy USWDS compiled JS: ${getSrcFrom("js")} →  ${paths.dist.js}`);
+    return src(`${getSrcFrom("js")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.js));
   },
 };
 
@@ -111,8 +124,20 @@ function handleError(error) {
   return this.emit("end");
 }
 
-function buildSass() {
+function logVersion() {
+  log(colorBlue, `uswds.version: ${settings.version}`);
+  return Promise.resolve('logged version');
+}
 
+function buildSass() {
+  let uswdsPath = "uswds"
+  if (settings.version === 3) {
+    uswdsPath = "@uswds/uswds";
+  }
+
+  const pkg = require(`../../${uswdsPath}/package.json`).version;
+
+  log(colorBlue, `Compiling with USWDS ${pkg}`);
   const buildSettings = {
     plugins: [
       autoprefixer({
@@ -123,9 +148,14 @@ function buildSass() {
       csso({ forceMediaMerge: false }),
     ],
     includes: [
-      paths.dist.theme,
-      paths.src.sass,
-      `${paths.src.sass}/packages`.replaceAll("//", "/")
+      // 1. local theme files
+      paths.dist.theme, 
+      // 2. uswds organization directory (npm packages)
+      getSrcFrom("uswds"),
+      // 3. v2 packages directory
+      `${getSrcFrom("sass")}/packages`.replaceAll("//", "/"),
+      // 4. local uswds package
+      getSrcFrom("sass")
     ],
   };
 
@@ -198,26 +228,29 @@ exports.copyTheme = copy.theme;
 exports.copyFonts = copy.fonts;
 exports.copyImages = copy.images;
 exports.copyJS = copy.js;
-exports.copyAssets = parallel(
+exports.copyAssets = series(
   copy.fonts,
   copy.images,
   copy.js
 );
-exports.copyAll = parallel(
+exports.copyAll = series(
   copy.theme,
   this.copyAssets
 );
-exports.compileSass = buildSass;
+exports.compileSass = series(logVersion, buildSass);
 exports.compileIcons = series(buildSprite, renameSprite, cleanSprite);
-exports.compile = parallel(
-  buildSass,
-  this.compileIcons
+exports.compile = series(
+  logVersion, 
+  parallel(
+    buildSass,
+    this.compileIcons
+  )
 );
 exports.updateUswds = series(
   this.copyAssets,
   this.compile
 );
 
-exports.init = series(this.copyAll, this.compile);
-exports.watch = series(buildSass, watchSass);
+exports.init = series(logVersion, this.copyAll, this.compile);
+exports.watch = series(logVersion, buildSass, watchSass);
 exports.default = this.watch;


### PR DESCRIPTION
Since the `uswds` package will publish from a `@uswds` org scope starting with USWDS 3.0.0, we need to update the gulpfile to allow for more seamless switching between USWDS 2.x defaults and USWDS 3.x defaults. 