### PR TITLE
USWDS-Compile - return projectSass styles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -160,7 +160,11 @@ function buildSass() {
   };
 
   return (
-    src([`${paths.dist.theme}/*.scss`.replaceAll("//", "/")])
+    src(
+      [
+        `${paths.dist.theme}/**/*.scss`.replaceAll("//", "/"), 
+        `${paths.src.projectSass}/**/*.scss`.replaceAll("//", "/")
+      ])
       .pipe(sourcemaps.init({ largeFile: true }))
       .pipe(
         sass({ includePaths: buildSettings.includes })


### PR DESCRIPTION
## Description
When running both the `compile` and `watch` tasks, the files in paths.src.projectSass are not included in the compiled CSS. 

Addresses Issue #19

### Steps to reproduce 
1. Install uswds-compile on a static project
1. Follow the USWDS-compile [usage instructions](https://github.com/uswds/uswds-compile#usage)
1. In your project's gulpfile.js, designate a custom directory for paths.src.projectSass
1. Check your compiled assets to see if the custom styles were included 

In the example shown below, you'll see that the projectSass directory is ignored during compilation. `index.css` does not compile and  the styles from the projectSass directory are not included inside styles.css:

![image](https://user-images.githubusercontent.com/93996430/163584098-73fce874-30bb-4f6d-97bd-a6d6c8c742e5.png)

## Proposed resolution
When the `paths.src.projectSass` is included in the buildSass task in the uswds-compile `gulpfile.js`, it compiles the expected files inside `paths.dist.css`.

![image](https://user-images.githubusercontent.com/93996430/163583810-bf7b68e2-c825-4361-b1f0-ceb17df11ea1.png)
