### PR TITLE
Icons: allow for custom directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ Function | Description
 `updateUswds` | `copyAssets` + `compile`
 `watch` | Compiles, then recompiles when there are changes to Sass files in `paths.dist.theme` and `paths.src.projectSass`
 
-
-## Running the compile functions
+### Running the compile functions
 For any function you defined as an `export` in your `gulpfile.js` you can run `npx gulp [function]`
 
 For example, if you have the following `gulpfile.js`:
@@ -134,20 +133,6 @@ With that setup, you could do the following in the terminal:
 - **Watch for changes and recompile:** `npx gulp watch`
 - **Initialize a new project:** `npx gulp init`
 - **Update USWDS static assets and recompile:** `npx gulp update`
-
----
-
-### Autoprefixer
-We use Autoprefixer for maximum browser compatibility. We target the the following browsers. When you compile with the USWDS compiler, we will apply Autoprefixer to all compiled code.
-
-```bash
-> 2%
-last 2 versions
-IE 11
-not dead
-```
-
----
 
 ### Updating the USWDS icon sprite
 
@@ -175,5 +160,17 @@ After running either `init` or `copyAssets`, you'll find USWDS images in the `pa
     uswds.sprite.projectOnly = true;
     ```
 1. Run either the `compile` or the `compileIcons` function to compile a new sprite. This sprite will include only the new project icons.
+
+## Autoprefixer
+We use Autoprefixer for maximum browser compatibility. We target the the following browsers. When you compile with the USWDS compiler, we will apply Autoprefixer to all compiled code.
+
+```bash
+> 2%
+last 2 versions
+IE 11
+not dead
+```
+
+---
 
 :rocket:

--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ Setting | Default | Description
 `paths.src.img` | `2`: `"./node_modules/uswds/dist/img"`<br />`3`: `"./node_modules/@uswds/uswds/dist/img"` | Source location of the USWDS images
 `paths.src.js` | `2`: `"./node_modules/uswds/dist/js"`<br />`3`: `"./node_modules/@uswds/uswds/dist/js"` | Source location of the USWDS compiled JavaScript files
 `paths.src.projectSass` | `"./sass"` | Source location of any existing project Sass files outside of `paths.dist.theme`. The `watch` script will watch this directory for changes.
+`paths.src.projectIcons` | `""` | Source location of any additional project icons to include in the icon sprite. (Use _only_ these project icons in the sprite by setting `sprite.projectOnly` to `true`.)
 `paths.dist.theme` | `"./sass"` | Project destination for theme files (Sass entry point and settings)
 `paths.dist.img` | `"./assets/uswds/images"` | Project destination for images
 `paths.dist.fonts` | `"./assets/uswds/fonts"` | Project destination for fonts
 `paths.dist.js` | `"./assets/uswds/js"` | Project destination for compiled JavaScript
 `paths.dist.css` | `"./assets/uswds/css"` | Project destination for compiled CSS
+`sprite.projectOnly` | `"./assets/uswds/css"` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite. 
 
 ### Functions
 Export USWDS Compile functions in your project's `gulpfile.js` to use them in your project.
@@ -151,6 +153,27 @@ not dead
 
 After running either `init` or `copyAssets`, you'll find USWDS images in the `paths.dist.img` directory. Any icon SVG file in `usa-icons` directory within the `paths.dist.img` directory will compile into the icon sprite when running the `compileIcons` function.
 
-We'll be updating and improving the icon workflow in subsequent releases.
+#### Add icons to the icon sprite
+
+1. Create a directory for the new icons anywhere in your project
+1. Add icons (typically from either `uswds-icons` or `material-icons`) to this directory.  **These icons will be added to the default USWDS icons in the sprite.**
+1. In your project Gulpfile, set `uswds.paths.src.projectIcons` to this new directory. For example
+    ```js
+    uswds.paths.src.projectIcons = "./assets/img/my-icons";
+    ```
+1. Run either the `compile` or the `compileIcons` function to compile a new sprite. This sprite includes the USWDS default icons and the new project icons.
+
+#### Use only project icons in the icon sprite
+1. Create a directory for the new icons anywhere in your project
+1. Add icons (typically from either `usa-icons`, `uswds-icons`, or `material-icons`) to this directory. **These will be the only icons included in the sprite.**
+1. In your project Gulpfile, set `uswds.paths.src.projectIcons` to this new directory. For example
+    ```js
+    uswds.paths.src.projectIcons = "./assets/img/my-icons";
+    ```
+1. In your project Gulpfile, set `uswds.sprite.projectOnly` to `true`. For example
+    ```js
+    uswds.sprite.projectOnly = true;
+    ```
+1. Run either the `compile` or the `compileIcons` function to compile a new sprite. This sprite will include only the new project icons.
 
 :rocket:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Setting | Default | Description
 `paths.dist.fonts` | `"./assets/uswds/fonts"` | Project destination for fonts
 `paths.dist.js` | `"./assets/uswds/js"` | Project destination for compiled JavaScript
 `paths.dist.css` | `"./assets/uswds/css"` | Project destination for compiled CSS
-`sprite.projectIconsOnly` | `"./assets/uswds/css"` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite. 
+`sprite.projectIconsOnly` | `false` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite. 
 
 ### Functions
 Export USWDS Compile functions in your project's `gulpfile.js` to use them in your project.

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Setting | Default | Description
 `paths.src.img` | `2`: `"./node_modules/uswds/dist/img"`<br />`3`: `"./node_modules/@uswds/uswds/dist/img"` | Source location of the USWDS images
 `paths.src.js` | `2`: `"./node_modules/uswds/dist/js"`<br />`3`: `"./node_modules/@uswds/uswds/dist/js"` | Source location of the USWDS compiled JavaScript files
 `paths.src.projectSass` | `"./sass"` | Source location of any existing project Sass files outside of `paths.dist.theme`. The `watch` script will watch this directory for changes.
-`paths.src.projectIcons` | `""` | Source location of any additional project icons to include in the icon sprite. (Use _only_ these project icons in the sprite by setting `sprite.projectOnly` to `true`.)
+`paths.src.projectIcons` | `""` | Source location of any additional project icons to include in the icon sprite. (Use _only_ these project icons in the sprite by setting `sprite.projectIconsOnly` to `true`.)
 `paths.dist.theme` | `"./sass"` | Project destination for theme files (Sass entry point and settings)
 `paths.dist.img` | `"./assets/uswds/images"` | Project destination for images
 `paths.dist.fonts` | `"./assets/uswds/fonts"` | Project destination for fonts
 `paths.dist.js` | `"./assets/uswds/js"` | Project destination for compiled JavaScript
 `paths.dist.css` | `"./assets/uswds/css"` | Project destination for compiled CSS
-`sprite.projectOnly` | `"./assets/uswds/css"` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite. 
+`sprite.projectIconsOnly` | `"./assets/uswds/css"` | Include _only_ the icons in `paths.src.projectIcons` in the icon sprite. 
 
 ### Functions
 Export USWDS Compile functions in your project's `gulpfile.js` to use them in your project.
@@ -155,9 +155,9 @@ After running either `init` or `copyAssets`, you'll find USWDS images in the `pa
     ```js
     uswds.paths.src.projectIcons = "./assets/img/my-icons";
     ```
-1. In your project Gulpfile, set `uswds.sprite.projectOnly` to `true`. For example
+1. In your project Gulpfile, set `uswds.sprite.projectIconsOnly` to `true`. For example
     ```js
-    uswds.sprite.projectOnly = true;
+    uswds.sprite.projectIconsOnly = true;
     ```
 1. Run either the `compile` or the `compileIcons` function to compile a new sprite. This sprite will include only the new project icons.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,7 @@ let settings = {
         img: null,
         js: null,
         projectSass: "./sass",
+        projectIcons: "",
         defaults: {
           v2: {
             uswds: "./node_modules/uswds/dist",
@@ -61,16 +62,15 @@ let settings = {
         fonts: "./assets/uswds/fonts",
         js: "./assets/uswds/js",
         css: "./assets/uswds/css",
-        icons: "",
       },
     },
     browserslist: ["> 2%", "last 2 versions", "IE 11", "not dead"],
   },
-  custom_sprites_only: false,
   sprite: {
     width: 24,
     height: 24,
     separator: "-",
+    projectOnly: false,
   },
 };
 
@@ -207,22 +207,22 @@ function getSpritePaths(spritePaths = []) {
     "/"
   );
 
-  const customSpritePath = paths.dist.icons.length
-    ? `${paths.dist.icons}/**/*.svg`.replaceAll("//", "/")
+  const customSpritePath = paths.src.projectIcons.length
+    ? `${paths.src.projectIcons}/**/*.svg`.replaceAll("//", "/")
     : "";
 
   if (customSpritePath) {
     spritePaths.push(customSpritePath);
 
-    if (settings.custom_sprites_only) {
+    if (settings.sprite.projectOnly) {
       return spritePaths;
     }
   }
 
-  if (settings.custom_sprites_only && !customSpritePath) {
+  if (settings.sprite.projectOnly && !customSpritePath) {
     log(
       colors.yellow,
-      `You've set custom_sprites_only to true, but haven't defined a custom path directory. Using default: "${defaultSpritePath}"`
+      `You've set sprite.projectOnly to true, but haven't defined a custom project icon path directory (paths.src.projectIcons). Using default: "${defaultSpritePath}"`
     );
   }
 
@@ -257,6 +257,7 @@ function cleanSprite() {
 
 exports.settings = settings;
 exports.paths = paths;
+exports.sprite = settings.sprite;
 exports.copyTheme = copy.theme;
 exports.copyFonts = copy.fonts;
 exports.copyImages = copy.images;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,8 @@ const log = console.log;
 const colors = {
   red: "\x1b[31m%s\x1b[0m",
   blue: "\x1b[34m%s\x1b[0m",
-  yellow: "\x1b[33m%s\x1b[0m"
-}
+  yellow: "\x1b[33m%s\x1b[0m",
+};
 
 /*
 ----------------------------------------
@@ -61,6 +61,7 @@ let settings = {
         fonts: "./assets/uswds/fonts",
         js: "./assets/uswds/js",
         css: "./assets/uswds/css",
+        icons: "",
       },
     },
     browserslist: ["> 2%", "last 2 versions", "IE 11", "not dead"],
@@ -199,16 +200,45 @@ function watchSass() {
     buildSass
   );
 }
-      `${paths.src.projectSass}/**/*.scss`.replaceAll("//", "/")
-    ], buildSass);
-};
+
+function getSpritePaths(spritePaths = []) {
+  const defaultSpritePath = `${paths.dist.img}/usa-icons/**/*.svg`.replaceAll(
+    "//",
+    "/"
+  );
+
+  const customSpritePath = paths.dist.icons.length
+    ? `${paths.dist.icons}/**/*.svg`.replaceAll("//", "/")
+    : "";
+
+  if (customSpritePath) {
+    spritePaths.push(customSpritePath);
+
+    if (settings.custom_sprites_only) {
+      return spritePaths;
+    }
+  }
+
+  if (settings.custom_sprites_only && !customSpritePath) {
+    log(
+      colors.yellow,
+      `You've set custom_sprites_only to true, but haven't defined a custom path directory. Using default: "${defaultSpritePath}"`
+    );
+  }
+
+  spritePaths.push(defaultSpritePath);
+
+  return spritePaths;
+}
 
 function buildSprite() {
-  return src(`${paths.dist.img}/usa-icons/**/*.svg`.replaceAll("//", "/"), {
+  const spritePaths = getSpritePaths();
 
+  return src(spritePaths, {
     allowEmpty: true,
   })
     .pipe(svgSprite())
+    .pipe(rename("usa-icons.svg"))
     .on("error", handleError)
     .pipe(dest(`${paths.dist.img}`));
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,11 @@ const del = require("del");
 const svgSprite = require("gulp-svgstore");
 const rename = require("gulp-rename");
 const log = console.log;
-const colorBlue = "\x1b[34m%s\x1b[0m";
+const colors = {
+  red: "\x1b[31m%s\x1b[0m",
+  blue: "\x1b[34m%s\x1b[0m",
+  yellow: "\x1b[33m%s\x1b[0m",
+};
 
 /*
 ----------------------------------------
@@ -96,20 +100,16 @@ USWDS specific tasks
 
 const copy = {
   theme() {
-    log(colorBlue, `Copy USWDS theme files: ${getSrcFrom("theme")} → ${paths.dist.theme}`);
-    return src(`${getSrcFrom("theme")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.theme));
+      colors.blue,
   },
   fonts() {
-    log(colorBlue, `Copy USWDS fonts: ${getSrcFrom("fonts")} → ${paths.dist.fonts}`);
-    return src(`${getSrcFrom("fonts")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.fonts));
+      colors.blue,
   },
   images() {
-    log(colorBlue, `Copy USWDS images: ${getSrcFrom("img")} →  ${paths.dist.img}`);
-    return src(`${getSrcFrom("img")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.img));
+      colors.blue,
   },
   js() {
-    log(colorBlue, `Copy USWDS compiled JS: ${getSrcFrom("js")} →  ${paths.dist.js}`);
-    return src(`${getSrcFrom("js")}/**/**`.replaceAll("//", "/")).pipe(dest(paths.dist.js));
+      colors.blue,
   },
 };
 
@@ -125,7 +125,7 @@ function handleError(error) {
 }
 
 function logVersion() {
-  log(colorBlue, `uswds.version: ${settings.version}`);
+  log(colors.blue, `uswds.version: ${settings.version}`);
   return Promise.resolve('logged version');
 }
 
@@ -137,7 +137,7 @@ function buildSass() {
 
   const pkg = require(`../../${uswdsPath}/package.json`).version;
 
-  log(colorBlue, `Compiling with USWDS ${pkg}`);
+  log(colors.blue, `Compiling with USWDS ${pkg}`);
   const buildSettings = {
     plugins: [
       autoprefixer({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ let settings = {
     width: 24,
     height: 24,
     separator: "-",
-    projectOnly: false,
+    projectIconsOnly: false,
   },
 };
 
@@ -214,15 +214,15 @@ function getSpritePaths(spritePaths = []) {
   if (customSpritePath) {
     spritePaths.push(customSpritePath);
 
-    if (settings.sprite.projectOnly) {
+    if (settings.sprite.projectIconsOnly) {
       return spritePaths;
     }
   }
 
-  if (settings.sprite.projectOnly && !customSpritePath) {
+  if (settings.sprite.projectIconsOnly && !customSpritePath) {
     log(
       colors.yellow,
-      `You've set sprite.projectOnly to true, but haven't defined a custom project icon path directory (paths.src.projectIcons). Using default: "${defaultSpritePath}"`
+      `You've set sprite.projectIconsOnly to true, but haven't defined a custom project icon path directory (paths.src.projectIcons). Using default: "${defaultSpritePath}"`
     );
   }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,8 @@ const log = console.log;
 const colors = {
   red: "\x1b[31m%s\x1b[0m",
   blue: "\x1b[34m%s\x1b[0m",
-  yellow: "\x1b[33m%s\x1b[0m",
-};
+  yellow: "\x1b[33m%s\x1b[0m"
+}
 
 /*
 ----------------------------------------
@@ -39,7 +39,7 @@ let settings = {
             theme: "./node_modules/uswds/dist/scss/theme",
             fonts: "./node_modules/uswds/dist/fonts",
             img: "./node_modules/uswds/dist/img",
-            js: "./node_modules/uswds/dist/js",    
+            js: "./node_modules/uswds/dist/js",
           },
           v3: {
             uswds: "./node_modules/@uswds",
@@ -48,8 +48,8 @@ let settings = {
             fonts: "./node_modules/@uswds/uswds/dist/fonts",
             img: "./node_modules/@uswds/uswds/dist/img",
             js: "./node_modules/@uswds/uswds/dist/js",
-          }
-        }
+          },
+        },
       },
       /**
        * ? project paths
@@ -63,19 +63,15 @@ let settings = {
         css: "./assets/uswds/css",
       },
     },
-    browserslist: [
-      "> 2%",
-      "last 2 versions",
-      "IE 11",
-      "not dead"
-    ],
+    browserslist: ["> 2%", "last 2 versions", "IE 11", "not dead"],
   },
+  custom_sprites_only: false,
   sprite: {
     width: 24,
     height: 24,
     separator: "-",
-  }
-}
+  },
+};
 
 let paths = settings.compile.paths;
 
@@ -84,7 +80,7 @@ let getSrcFrom = (key) => {
     return paths.src[key];
   }
   return paths.src.defaults[`v${settings.version}`][key];
-}
+};
 
 /*
 ----------------------------------------
@@ -100,16 +96,40 @@ USWDS specific tasks
 
 const copy = {
   theme() {
+    log(
       colors.blue,
+      `Copy USWDS theme files: ${getSrcFrom("theme")} → ${paths.dist.theme}`
+    );
+    return src(`${getSrcFrom("theme")}/**/**`.replaceAll("//", "/")).pipe(
+      dest(paths.dist.theme)
+    );
   },
   fonts() {
+    log(
       colors.blue,
+      `Copy USWDS fonts: ${getSrcFrom("fonts")} → ${paths.dist.fonts}`
+    );
+    return src(`${getSrcFrom("fonts")}/**/**`.replaceAll("//", "/")).pipe(
+      dest(paths.dist.fonts)
+    );
   },
   images() {
+    log(
       colors.blue,
+      `Copy USWDS images: ${getSrcFrom("img")} →  ${paths.dist.img}`
+    );
+    return src(`${getSrcFrom("img")}/**/**`.replaceAll("//", "/")).pipe(
+      dest(paths.dist.img)
+    );
   },
   js() {
+    log(
       colors.blue,
+      `Copy USWDS compiled JS: ${getSrcFrom("js")} →  ${paths.dist.js}`
+    );
+    return src(`${getSrcFrom("js")}/**/**`.replaceAll("//", "/")).pipe(
+      dest(paths.dist.js)
+    );
   },
 };
 
@@ -126,11 +146,11 @@ function handleError(error) {
 
 function logVersion() {
   log(colors.blue, `uswds.version: ${settings.version}`);
-  return Promise.resolve('logged version');
+  return Promise.resolve("logged version");
 }
 
 function buildSass() {
-  let uswdsPath = "uswds"
+  let uswdsPath = "uswds";
   if (settings.version === 3) {
     uswdsPath = "@uswds/uswds";
   }
@@ -143,46 +163,49 @@ function buildSass() {
       autoprefixer({
         cascade: false,
         grid: true,
-        overrideBrowserslist: settings.compile.browserslist
+        overrideBrowserslist: settings.compile.browserslist,
       }),
       csso({ forceMediaMerge: false }),
     ],
     includes: [
       // 1. local theme files
-      paths.dist.theme, 
+      paths.dist.theme,
       // 2. uswds organization directory (npm packages)
       getSrcFrom("uswds"),
       // 3. v2 packages directory
       `${getSrcFrom("sass")}/packages`.replaceAll("//", "/"),
       // 4. local uswds package
-      getSrcFrom("sass")
+      getSrcFrom("sass"),
     ],
   };
 
-  return (
-    src([`${paths.dist.theme}/*.scss`.replaceAll("//", "/")])
-      .pipe(sourcemaps.init({ largeFile: true }))
-      .pipe(
-        sass({ includePaths: buildSettings.includes })
-          .on("error", handleError)
-      )
-      .pipe(replace(/\buswds @version\b/g, `based on uswds v${pkg}`))
-      .pipe(postcss(buildSettings.plugins))
-      .pipe(sourcemaps.write("."))
-      .pipe(dest(paths.dist.css))
-  );
+  return src([`${paths.dist.theme}/*.scss`.replaceAll("//", "/")])
+    .pipe(sourcemaps.init({ largeFile: true }))
+    .pipe(
+      sass({ includePaths: buildSettings.includes }).on("error", handleError)
+    )
+    .pipe(replace(/\buswds @version\b/g, `based on uswds v${pkg}`))
+    .pipe(postcss(buildSettings.plugins))
+    .pipe(sourcemaps.write("."))
+    .pipe(dest(paths.dist.css));
 }
 
 function watchSass() {
   return watch(
     [
-      `${paths.dist.theme}/**/*.scss`.replaceAll("//", "/"), 
+      `${paths.dist.theme}/**/*.scss`.replaceAll("//", "/"),
+      `${paths.src.projectSass}/**/*.scss`.replaceAll("//", "/"),
+    ],
+    buildSass
+  );
+}
       `${paths.src.projectSass}/**/*.scss`.replaceAll("//", "/")
     ], buildSass);
 };
 
 function buildSprite() {
   return src(`${paths.dist.img}/usa-icons/**/*.svg`.replaceAll("//", "/"), {
+
     allowEmpty: true,
   })
     .pipe(svgSprite())
@@ -208,28 +231,12 @@ exports.copyTheme = copy.theme;
 exports.copyFonts = copy.fonts;
 exports.copyImages = copy.images;
 exports.copyJS = copy.js;
-exports.copyAssets = series(
-  copy.fonts,
-  copy.images,
-  copy.js
-);
-exports.copyAll = series(
-  copy.theme,
-  this.copyAssets
-);
+exports.copyAssets = series(copy.fonts, copy.images, copy.js);
+exports.copyAll = series(copy.theme, this.copyAssets);
 exports.compileSass = series(logVersion, buildSass);
 exports.compileIcons = series(buildSprite, renameSprite, cleanSprite);
-exports.compile = series(
-  logVersion, 
-  parallel(
-    buildSass,
-    this.compileIcons
-  )
-);
-exports.updateUswds = series(
-  this.copyAssets,
-  this.compile
-);
+exports.compile = series(logVersion, parallel(buildSass, this.compileIcons));
+exports.updateUswds = series(this.copyAssets, this.compile);
 
 exports.init = series(logVersion, this.copyAll, this.compile);
 exports.watch = series(logVersion, buildSass, watchSass);


### PR DESCRIPTION
# Description
**Allow custom icons directory.** You can now pass an optional directory to compile icons.  Additionally, you can choose to **only** watch this newly defined directory. The default behavior is to combine it with `usa-icons`. Closes #30.

```mermaid
    flowchart TD;
    usa-icons--Default-->A[usa-icons only]
    usa-icons-->uswds.paths.dist.icons-->custom_sprites_only-->Yes & No
    Yes-->B[Custom only]
    No--Default-->C[Combined]
```
💡Flow chart is made in markdown - [see GH Docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).

# How to test
Test branch on Site with instructions available in https://github.com/uswds/uswds-site/pull/1614