### PR TITLE
USWDS-Compile: Create add-issue-labels workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,7 +1,7 @@
 name: Bug Report 🐞
 description: Report a bug and help USWDS Compile improve.
 title: "USWDS-Compile - Bug: [YOUR TITLE]"
-labels: ['Type: Bug','Status: Triage','Needs: Confirmation']
+labels: ['Type: Bug','Needs: Confirmation']
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
 name: Feature Request 💡
 description: Suggest a new idea for USWDS Compile.
 title: 'USWDS-Compile - Feature: [YOUR TITLE]'
-labels: ['Type: Feature Request','Status: Triage']
+labels: ['Type: Feature Request']
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/add-issue-labels.yml
+++ b/.github/workflows/add-issue-labels.yml
@@ -1,0 +1,20 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Status: Triage"]
+            })


### PR DESCRIPTION
# Summary
> **Note:**
> This action will also be added to every USWDS repo that adds issues to the project board.

Added a workflow that creates a "Status: Triage" label on all new issue submissions. 

More information about the action: [github-script action](https://github.com/actions/github-script)

## Breaking change

This is not a breaking change.

## Related issue

Closes #2154

## Related pull requests

No changelog is required for this update. 

## Preview link

Preview link: N/A

## Problem statement

All new USWDS project issues should receive the "Status: Triage" label when opened. This label is important because we sort through items with this label in the [project Triage tab](https://github.com/orgs/uswds/projects/8/views/26) during issue triage. However, the "Status: Triage" label is currently only added to issues created via our bug or feature request templates.

## Solution

Creating a workflow that applies the "Status: Triage" label to all newly opened issue will ensure that all new issues are added to the project triage tab.

## Testing and review

To test:
1. Open a new [blank issue](https://github.com/amyleadem/issue-template/issues/new) in this [test repo](https://github.com/amyleadem/issue-template).
2. Confirm that the issue receives the "Status: Triage" label (This might take a minute to complete)
3. Confirm that the add labels action file in this PR matches the one in the [demo repo](https://github.com/amyleadem/issue-template/blob/main/.github/workflows/add-issue-labels.yml)
4. Confirm that this action is a reasonable addition.

