### PR TITLE
USWDS-Compile - Bugfix: Fix sourcemaps pathing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,10 @@ function buildSass() {
   return src([`${paths.dist.theme}/*.scss`.replace("//", "/")])
     .pipe(sourcemaps.init({ largeFile: true }))
     .pipe(
-      sass({ includePaths: buildSettings.includes }).on("error", handleError)
+      sass({
+        outputStyle: "compressed",
+        includePaths: buildSettings.includes,
+      }).on("error", handleError)
     )
     .pipe(replace(/\buswds @version\b/g, `based on uswds v${pkg}`))
     .pipe(postcss(buildSettings.plugins))


### PR DESCRIPTION
**Sourcemaps show correct paths.** Generated CSS now points to the correct source locations. Closes #61.


## How to test

1. Checkout `jm-test-compile-sourcemaps-fix` from `uswds/uswds-site` repo.
2. Run `npm install && npm start`.
3. Visit `/documentation/settings/` page.
4. Scroll down to yellow alert.
5. In the inspector, verify that `site-note` correctly points to `_uswds-theme-custom-styles.scss` (i.e. that the sourcemaps link is now correct)
