### PR TITLE
Update non vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "autoprefixer": "10.4.18",
+        "autoprefixer": "10.4.19",
         "del": "6.1.1",
         "gulp": "4.0.2",
         "gulp-postcss": "9.0.1",
@@ -18,9 +18,9 @@
         "gulp-sass": "5.1.0",
         "gulp-sourcemaps": "3.0.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "8.4.35",
+        "postcss": "^8.4.38",
         "postcss-csso": "6.0.1",
-        "sass-embedded": "1.71.1"
+        "sass-embedded": "1.74.1"
       },
       "devDependencies": {
         "@uswds/uswds": "^3.8.0",
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.18",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.18.tgz",
-      "integrity": "sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==",
+      "version": "10.4.19",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
       "funding": [
         {
           "type": "opencollective",
@@ -574,7 +574,7 @@
       ],
       "dependencies": {
         "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001591",
+        "caniuse-lite": "^1.0.30001599",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001597",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
-      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
+      "version": "1.0.30001607",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==",
       "funding": [
         {
           "type": "opencollective",
@@ -3743,9 +3743,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3763,7 +3763,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4326,9 +4326,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.71.1.tgz",
-      "integrity": "sha512-nOmqErO1zd1wjvTbDscLZZ3fv5JPeQfaKuo0UCjYm7qPbpQcycp0l3nFZHxovjLjCetJ9IrLOADdznFYKV0f1A==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.74.1.tgz",
+      "integrity": "sha512-VnrsLUfLVuLNq8Zrz6oaYmJ+hK5saaOhuwRC58yAcXYM+CRbS+6us3ab2+PE2a94H2V+cPU4XFvqibfz3C/XSw==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -4341,28 +4341,29 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.71.1",
-        "sass-embedded-android-arm64": "1.71.1",
-        "sass-embedded-android-ia32": "1.71.1",
-        "sass-embedded-android-x64": "1.71.1",
-        "sass-embedded-darwin-arm64": "1.71.1",
-        "sass-embedded-darwin-x64": "1.71.1",
-        "sass-embedded-linux-arm": "1.71.1",
-        "sass-embedded-linux-arm64": "1.71.1",
-        "sass-embedded-linux-ia32": "1.71.1",
-        "sass-embedded-linux-musl-arm": "1.71.1",
-        "sass-embedded-linux-musl-arm64": "1.71.1",
-        "sass-embedded-linux-musl-ia32": "1.71.1",
-        "sass-embedded-linux-musl-x64": "1.71.1",
-        "sass-embedded-linux-x64": "1.71.1",
-        "sass-embedded-win32-ia32": "1.71.1",
-        "sass-embedded-win32-x64": "1.71.1"
+        "sass-embedded-android-arm": "1.74.1",
+        "sass-embedded-android-arm64": "1.74.1",
+        "sass-embedded-android-ia32": "1.74.1",
+        "sass-embedded-android-x64": "1.74.1",
+        "sass-embedded-darwin-arm64": "1.74.1",
+        "sass-embedded-darwin-x64": "1.74.1",
+        "sass-embedded-linux-arm": "1.74.1",
+        "sass-embedded-linux-arm64": "1.74.1",
+        "sass-embedded-linux-ia32": "1.74.1",
+        "sass-embedded-linux-musl-arm": "1.74.1",
+        "sass-embedded-linux-musl-arm64": "1.74.1",
+        "sass-embedded-linux-musl-ia32": "1.74.1",
+        "sass-embedded-linux-musl-x64": "1.74.1",
+        "sass-embedded-linux-x64": "1.74.1",
+        "sass-embedded-win32-arm64": "1.74.1",
+        "sass-embedded-win32-ia32": "1.74.1",
+        "sass-embedded-win32-x64": "1.74.1"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.71.1.tgz",
-      "integrity": "sha512-Pq6TlRg9lIYsZDo9XNQZnSg6grQKzBG3ssdv0W1SnYS1BzGKwbg8XnlUA/pVxK76BKEm8i+0DA4y8cZ8A3tmpw==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.74.1.tgz",
+      "integrity": "sha512-1Sy1HP9setmaIFAKKuYpIa3RrKFNmuXhj9sKs8KTWK7+zRSH6R9ZvKRW2R1AwCplQ75XnXSAVmp09rum9SiOcw==",
       "cpu": [
         "arm"
       ],
@@ -4378,9 +4379,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.71.1.tgz",
-      "integrity": "sha512-a7wJ1MM6sBwcM/8vIvvnwc9spoeNimNeXZpN9baSV4Ylthmr4GkTYYtf96Z/XYLdG5KBgYlxMs5T3OgqafdUMg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.74.1.tgz",
+      "integrity": "sha512-+Ob3WZkR/PzTToPdluptY4BR/+ROCiERr+DT/Fbb31S/DA+HKAegsnwAS4TTnEy8JTtnxFMwSm5xtB9xpchjoQ==",
       "cpu": [
         "arm64"
       ],
@@ -4396,9 +4397,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.71.1.tgz",
-      "integrity": "sha512-tn3WZNdKQtr/DSzl4cQIDZkTO3JuuMxPvM/T+U7gBFyhU62NyF5wvwBnuh+BN3iaMowfkSknzCZCjyJDwnkDjw==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.74.1.tgz",
+      "integrity": "sha512-oxKEVvu9VxY1wxhB69HHZlLvhAj3W0gcyFYi88s+gGzgdqpZ2Ohf1z7NJrI+SRUTYVLQ+sWd3Npt0SHWTFoDKA==",
       "cpu": [
         "ia32"
       ],
@@ -4414,9 +4415,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.71.1.tgz",
-      "integrity": "sha512-l72Pqxfb/pArpOLyWsuL9s8ODWupRGATWTPwUT/GjVdSQJO/lQL5DopXb55Cwh2T7t2G10e+uXTEMKz0qngoWQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.74.1.tgz",
+      "integrity": "sha512-Bg5Vx5sgl04K0cHSTniPigiB1zT6nmSJZE8Pq/s35Gze4awzoSDGE8tC65K7f+isKx9FtL9mB+7bEgCJdCvllA==",
       "cpu": [
         "x64"
       ],
@@ -4432,9 +4433,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.71.1.tgz",
-      "integrity": "sha512-3eZDAcJBwoG0Kyasa/EbaKt1Jn2y0GHvCd0Oas/VtMsYL+/6abiCO1l8YltdxER4jvuHUKE2Ow7J6T6sC+vVQQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.74.1.tgz",
+      "integrity": "sha512-DyYmU8qQ7QGGB0RvPUabOsU5YxGxdZd6X3IwyM6KIqziPtjrafoBtcMuWK9o3jg3NE9tL4SUlDezo8VJ87lJ/g==",
       "cpu": [
         "arm64"
       ],
@@ -4450,9 +4451,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.71.1.tgz",
-      "integrity": "sha512-/9FtMPVdQalhsRCD9opNIlZqJKe7veCjWsdj0J9utbc2bNCTYswXNQtC/jWJTjE9/gQ0+w5zwg9+fQzltdYh1w==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.74.1.tgz",
+      "integrity": "sha512-SO3VbGaa/zGzuibiNocSScnS9VZxFY6lULZMfkS6+Sgd3YQgnbvKLaMmfb6kUnETA11rO7jVOTfoNHPtG8n9NA==",
       "cpu": [
         "x64"
       ],
@@ -4468,9 +4469,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.71.1.tgz",
-      "integrity": "sha512-l7NEn0gji6GTN+p00DP2zZl9SE501Zy5obTA3beiD6+vQy7lCEC6vpNi/ZrlC6eRmgY2OKSBB2lfW7KSej9Hkg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.74.1.tgz",
+      "integrity": "sha512-mBssC2/aXn1SjI1rM4BM1VPc7w2g8K3Nrq6DDDt4Q10TINBuT3GPnIMb7BlQDpOnHD13GvaL53NDGW3QYWSgew==",
       "cpu": [
         "arm"
       ],
@@ -4486,9 +4487,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.71.1.tgz",
-      "integrity": "sha512-zUSmqeqcgTb3VjZggk9a9xB2ZGaAe/TYAi/vYRPNLY/f7dZSrsa9Ejo+LUm2aNl6V8hFzMz7BpoKsaRQJnb9GQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.74.1.tgz",
+      "integrity": "sha512-sXmREHeqAYwAi71DfnlvyEj0w3B+xMA6C8cIbM4VNP5FCVv4QkIeGCuTH0s/vyBwFKD9+cj9EhQ3UmUUgVP3kg==",
       "cpu": [
         "arm64"
       ],
@@ -4504,9 +4505,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.71.1.tgz",
-      "integrity": "sha512-NvzSljfc/Kw9/0CSn91AsINV2nh8vxhFe2cKexPMwvAqv/etU84dJMfJejxPJ39PmMqT1KvC4G+Qt2+6Mpe7oQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.74.1.tgz",
+      "integrity": "sha512-59n5kFmKcPObQjpK35ww+Fq9FonwZMj3khyl5Cdz2HERdq8nE7JltjdquBNkqp4vSvu7qqnErxFdcZNI1X4LUg==",
       "cpu": [
         "ia32"
       ],
@@ -4522,9 +4523,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.71.1.tgz",
-      "integrity": "sha512-1O37K5EgSeQjCBizIF9xdZJw3mh5XYHOnsB4+65CLZg4ac84ragjFv9d9rYhwGs9QSgg1MoOv7VWnEIxQ8Pp9Q==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.74.1.tgz",
+      "integrity": "sha512-xR5hmpRYAvohCRQ2jpkd/p3GHTQ7+KirjQPOaCEzl0RfCPwaqXh91EIvhkuWWE+8Sl9DZd997oucg5leuN6XFQ==",
       "cpu": [
         "arm"
       ],
@@ -4537,9 +4538,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.71.1.tgz",
-      "integrity": "sha512-Agtf6BcYQ0mt+jVDcRcN7bDPrMAQOWMeX15NTlQH1rO8voObLo6ThVl2NUkiZyyVmu7a6YOrCxpGBVAK1cLGOg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.74.1.tgz",
+      "integrity": "sha512-Ws3pMukEKdBXRLroj+kmrJohPIOG43J09sEU/ngxyv8SOKnHdI/5EnhOqJiO+8HUas8Pen/NCYrLYSOydnr3uQ==",
       "cpu": [
         "arm64"
       ],
@@ -4552,9 +4553,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.71.1.tgz",
-      "integrity": "sha512-Cd5sJkt70bSlYEXUSj9mPMKZLzDL8LGcBKUIfQRrcBKjmzD2Va2eLq4Zati9Xzt54unuDp4bAUUTyvQmjLzFmA==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.74.1.tgz",
+      "integrity": "sha512-F6yQI+VBgsCuriUF4F8SfJq8wiln3OlveWt/DY6DVXxd9oGZBFxZC/YHWcpKexuQtPrFXOVoCNmf0EgiIzAXig==",
       "cpu": [
         "ia32"
       ],
@@ -4567,9 +4568,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.71.1.tgz",
-      "integrity": "sha512-uVfYms/lf4QVSvtQXkSm+Bq3wVsvkRMI30ca82rRwpwebxSaTbUr+uLnskh8QvbyfsbMyrzZQU0SCrO3uCua1A==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.74.1.tgz",
+      "integrity": "sha512-qXCMa5Dkt63re5DaRZeD6OXHD9x8DCSWrcX/a+I6RVNNcwz4ez32Fvc8ZAM7QRdMW8w85v7yOFG0FEwZuFYuBQ==",
       "cpu": [
         "x64"
       ],
@@ -4582,9 +4583,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.71.1.tgz",
-      "integrity": "sha512-7BXniYic16+MQx0InyH8OXburLPGMRYRWf0l/t/fRkNkUHWFl7NQPAX0yvj73c/PKOdaYEUY6isNB4OGUGtZHQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.74.1.tgz",
+      "integrity": "sha512-2o6DL/NPLvf7AgNOpq12txhH+s17qlbqCw/BeNFMk9z50LdWkcQZXkDB4R9EA8CwPv65e84/j4+rrxVo8DB1iA==",
       "cpu": [
         "x64"
       ],
@@ -4599,10 +4600,28 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.74.1.tgz",
+      "integrity": "sha512-y1vliHa37TIfyniKp/G24PUyD2MgbTT3IuuCnkgQjZztiz61Dsmr9g1ueIaWG2EtMGHltG0Ly6uwUzBmqVKKaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "sass": "dart-sass/sass.bat"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.71.1.tgz",
-      "integrity": "sha512-ZDhL6hvekeKDkZ1wUj6wN0thrB/7wOO8HaQoagk+pKaHoa0Py7OLR/m9mQM8S13mZpUQduNsznmXV1fOss4GOg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.74.1.tgz",
+      "integrity": "sha512-DgaxdgdI6hl8X4cCR0C/8ksGgzA9asvJE3JEZqqmli+cg3QO8om2q3qkJi+3HLuhT3qAzWlGJwlvxm2L5toR3A==",
       "cpu": [
         "ia32"
       ],
@@ -4618,11 +4637,10 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.71.1.tgz",
-      "integrity": "sha512-ecWP1TFUA9ujOuOTJfWC1iZsSZOdQy5OxIEHqoERxunyjwzkiTxfN8J7Y4bNQ5uwb4K0brxWyIM8Fq+UgDqcZA==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.74.1.tgz",
+      "integrity": "sha512-4FXBj73rWlzOXQMBtl58F2qjXD2hdO33ozQlY2AviiJfAhdh4lxsuusDn1rLH0ECzoDsIdbDGQdhZ5/n3C8djQ==",
       "cpu": [
-        "arm64",
         "x64"
       ],
       "optional": true,
@@ -4857,9 +4875,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6143,12 +6161,12 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
-      "version": "10.4.18",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.18.tgz",
-      "integrity": "sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==",
+      "version": "10.4.19",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
       "requires": {
         "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001591",
+        "caniuse-lite": "^1.0.30001599",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -6338,9 +6356,9 @@
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
     },
     "caniuse-lite": {
-      "version": "1.0.30001597",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
-      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w=="
+      "version": "1.0.30001607",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz",
+      "integrity": "sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w=="
     },
     "cheerio": {
       "version": "1.0.0-rc.10",
@@ -8576,13 +8594,13 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "postcss-csso": {
@@ -8994,30 +9012,31 @@
       }
     },
     "sass-embedded": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.71.1.tgz",
-      "integrity": "sha512-nOmqErO1zd1wjvTbDscLZZ3fv5JPeQfaKuo0UCjYm7qPbpQcycp0l3nFZHxovjLjCetJ9IrLOADdznFYKV0f1A==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.74.1.tgz",
+      "integrity": "sha512-VnrsLUfLVuLNq8Zrz6oaYmJ+hK5saaOhuwRC58yAcXYM+CRbS+6us3ab2+PE2a94H2V+cPU4XFvqibfz3C/XSw==",
       "requires": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
-        "sass-embedded-android-arm": "1.71.1",
-        "sass-embedded-android-arm64": "1.71.1",
-        "sass-embedded-android-ia32": "1.71.1",
-        "sass-embedded-android-x64": "1.71.1",
-        "sass-embedded-darwin-arm64": "1.71.1",
-        "sass-embedded-darwin-x64": "1.71.1",
-        "sass-embedded-linux-arm": "1.71.1",
-        "sass-embedded-linux-arm64": "1.71.1",
-        "sass-embedded-linux-ia32": "1.71.1",
-        "sass-embedded-linux-musl-arm": "1.71.1",
-        "sass-embedded-linux-musl-arm64": "1.71.1",
-        "sass-embedded-linux-musl-ia32": "1.71.1",
-        "sass-embedded-linux-musl-x64": "1.71.1",
-        "sass-embedded-linux-x64": "1.71.1",
-        "sass-embedded-win32-ia32": "1.71.1",
-        "sass-embedded-win32-x64": "1.71.1",
+        "sass-embedded-android-arm": "1.74.1",
+        "sass-embedded-android-arm64": "1.74.1",
+        "sass-embedded-android-ia32": "1.74.1",
+        "sass-embedded-android-x64": "1.74.1",
+        "sass-embedded-darwin-arm64": "1.74.1",
+        "sass-embedded-darwin-x64": "1.74.1",
+        "sass-embedded-linux-arm": "1.74.1",
+        "sass-embedded-linux-arm64": "1.74.1",
+        "sass-embedded-linux-ia32": "1.74.1",
+        "sass-embedded-linux-musl-arm": "1.74.1",
+        "sass-embedded-linux-musl-arm64": "1.74.1",
+        "sass-embedded-linux-musl-ia32": "1.74.1",
+        "sass-embedded-linux-musl-x64": "1.74.1",
+        "sass-embedded-linux-x64": "1.74.1",
+        "sass-embedded-win32-arm64": "1.74.1",
+        "sass-embedded-win32-ia32": "1.74.1",
+        "sass-embedded-win32-x64": "1.74.1",
         "supports-color": "^8.1.1",
         "varint": "^6.0.0"
       },
@@ -9033,99 +9052,105 @@
       }
     },
     "sass-embedded-android-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.71.1.tgz",
-      "integrity": "sha512-Pq6TlRg9lIYsZDo9XNQZnSg6grQKzBG3ssdv0W1SnYS1BzGKwbg8XnlUA/pVxK76BKEm8i+0DA4y8cZ8A3tmpw==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.74.1.tgz",
+      "integrity": "sha512-1Sy1HP9setmaIFAKKuYpIa3RrKFNmuXhj9sKs8KTWK7+zRSH6R9ZvKRW2R1AwCplQ75XnXSAVmp09rum9SiOcw==",
       "optional": true
     },
     "sass-embedded-android-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.71.1.tgz",
-      "integrity": "sha512-a7wJ1MM6sBwcM/8vIvvnwc9spoeNimNeXZpN9baSV4Ylthmr4GkTYYtf96Z/XYLdG5KBgYlxMs5T3OgqafdUMg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.74.1.tgz",
+      "integrity": "sha512-+Ob3WZkR/PzTToPdluptY4BR/+ROCiERr+DT/Fbb31S/DA+HKAegsnwAS4TTnEy8JTtnxFMwSm5xtB9xpchjoQ==",
       "optional": true
     },
     "sass-embedded-android-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.71.1.tgz",
-      "integrity": "sha512-tn3WZNdKQtr/DSzl4cQIDZkTO3JuuMxPvM/T+U7gBFyhU62NyF5wvwBnuh+BN3iaMowfkSknzCZCjyJDwnkDjw==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.74.1.tgz",
+      "integrity": "sha512-oxKEVvu9VxY1wxhB69HHZlLvhAj3W0gcyFYi88s+gGzgdqpZ2Ohf1z7NJrI+SRUTYVLQ+sWd3Npt0SHWTFoDKA==",
       "optional": true
     },
     "sass-embedded-android-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.71.1.tgz",
-      "integrity": "sha512-l72Pqxfb/pArpOLyWsuL9s8ODWupRGATWTPwUT/GjVdSQJO/lQL5DopXb55Cwh2T7t2G10e+uXTEMKz0qngoWQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.74.1.tgz",
+      "integrity": "sha512-Bg5Vx5sgl04K0cHSTniPigiB1zT6nmSJZE8Pq/s35Gze4awzoSDGE8tC65K7f+isKx9FtL9mB+7bEgCJdCvllA==",
       "optional": true
     },
     "sass-embedded-darwin-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.71.1.tgz",
-      "integrity": "sha512-3eZDAcJBwoG0Kyasa/EbaKt1Jn2y0GHvCd0Oas/VtMsYL+/6abiCO1l8YltdxER4jvuHUKE2Ow7J6T6sC+vVQQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.74.1.tgz",
+      "integrity": "sha512-DyYmU8qQ7QGGB0RvPUabOsU5YxGxdZd6X3IwyM6KIqziPtjrafoBtcMuWK9o3jg3NE9tL4SUlDezo8VJ87lJ/g==",
       "optional": true
     },
     "sass-embedded-darwin-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.71.1.tgz",
-      "integrity": "sha512-/9FtMPVdQalhsRCD9opNIlZqJKe7veCjWsdj0J9utbc2bNCTYswXNQtC/jWJTjE9/gQ0+w5zwg9+fQzltdYh1w==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.74.1.tgz",
+      "integrity": "sha512-SO3VbGaa/zGzuibiNocSScnS9VZxFY6lULZMfkS6+Sgd3YQgnbvKLaMmfb6kUnETA11rO7jVOTfoNHPtG8n9NA==",
       "optional": true
     },
     "sass-embedded-linux-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.71.1.tgz",
-      "integrity": "sha512-l7NEn0gji6GTN+p00DP2zZl9SE501Zy5obTA3beiD6+vQy7lCEC6vpNi/ZrlC6eRmgY2OKSBB2lfW7KSej9Hkg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.74.1.tgz",
+      "integrity": "sha512-mBssC2/aXn1SjI1rM4BM1VPc7w2g8K3Nrq6DDDt4Q10TINBuT3GPnIMb7BlQDpOnHD13GvaL53NDGW3QYWSgew==",
       "optional": true
     },
     "sass-embedded-linux-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.71.1.tgz",
-      "integrity": "sha512-zUSmqeqcgTb3VjZggk9a9xB2ZGaAe/TYAi/vYRPNLY/f7dZSrsa9Ejo+LUm2aNl6V8hFzMz7BpoKsaRQJnb9GQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.74.1.tgz",
+      "integrity": "sha512-sXmREHeqAYwAi71DfnlvyEj0w3B+xMA6C8cIbM4VNP5FCVv4QkIeGCuTH0s/vyBwFKD9+cj9EhQ3UmUUgVP3kg==",
       "optional": true
     },
     "sass-embedded-linux-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.71.1.tgz",
-      "integrity": "sha512-NvzSljfc/Kw9/0CSn91AsINV2nh8vxhFe2cKexPMwvAqv/etU84dJMfJejxPJ39PmMqT1KvC4G+Qt2+6Mpe7oQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.74.1.tgz",
+      "integrity": "sha512-59n5kFmKcPObQjpK35ww+Fq9FonwZMj3khyl5Cdz2HERdq8nE7JltjdquBNkqp4vSvu7qqnErxFdcZNI1X4LUg==",
       "optional": true
     },
     "sass-embedded-linux-musl-arm": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.71.1.tgz",
-      "integrity": "sha512-1O37K5EgSeQjCBizIF9xdZJw3mh5XYHOnsB4+65CLZg4ac84ragjFv9d9rYhwGs9QSgg1MoOv7VWnEIxQ8Pp9Q==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.74.1.tgz",
+      "integrity": "sha512-xR5hmpRYAvohCRQ2jpkd/p3GHTQ7+KirjQPOaCEzl0RfCPwaqXh91EIvhkuWWE+8Sl9DZd997oucg5leuN6XFQ==",
       "optional": true
     },
     "sass-embedded-linux-musl-arm64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.71.1.tgz",
-      "integrity": "sha512-Agtf6BcYQ0mt+jVDcRcN7bDPrMAQOWMeX15NTlQH1rO8voObLo6ThVl2NUkiZyyVmu7a6YOrCxpGBVAK1cLGOg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.74.1.tgz",
+      "integrity": "sha512-Ws3pMukEKdBXRLroj+kmrJohPIOG43J09sEU/ngxyv8SOKnHdI/5EnhOqJiO+8HUas8Pen/NCYrLYSOydnr3uQ==",
       "optional": true
     },
     "sass-embedded-linux-musl-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.71.1.tgz",
-      "integrity": "sha512-Cd5sJkt70bSlYEXUSj9mPMKZLzDL8LGcBKUIfQRrcBKjmzD2Va2eLq4Zati9Xzt54unuDp4bAUUTyvQmjLzFmA==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.74.1.tgz",
+      "integrity": "sha512-F6yQI+VBgsCuriUF4F8SfJq8wiln3OlveWt/DY6DVXxd9oGZBFxZC/YHWcpKexuQtPrFXOVoCNmf0EgiIzAXig==",
       "optional": true
     },
     "sass-embedded-linux-musl-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.71.1.tgz",
-      "integrity": "sha512-uVfYms/lf4QVSvtQXkSm+Bq3wVsvkRMI30ca82rRwpwebxSaTbUr+uLnskh8QvbyfsbMyrzZQU0SCrO3uCua1A==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.74.1.tgz",
+      "integrity": "sha512-qXCMa5Dkt63re5DaRZeD6OXHD9x8DCSWrcX/a+I6RVNNcwz4ez32Fvc8ZAM7QRdMW8w85v7yOFG0FEwZuFYuBQ==",
       "optional": true
     },
     "sass-embedded-linux-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.71.1.tgz",
-      "integrity": "sha512-7BXniYic16+MQx0InyH8OXburLPGMRYRWf0l/t/fRkNkUHWFl7NQPAX0yvj73c/PKOdaYEUY6isNB4OGUGtZHQ==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.74.1.tgz",
+      "integrity": "sha512-2o6DL/NPLvf7AgNOpq12txhH+s17qlbqCw/BeNFMk9z50LdWkcQZXkDB4R9EA8CwPv65e84/j4+rrxVo8DB1iA==",
+      "optional": true
+    },
+    "sass-embedded-win32-arm64": {
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.74.1.tgz",
+      "integrity": "sha512-y1vliHa37TIfyniKp/G24PUyD2MgbTT3IuuCnkgQjZztiz61Dsmr9g1ueIaWG2EtMGHltG0Ly6uwUzBmqVKKaA==",
       "optional": true
     },
     "sass-embedded-win32-ia32": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.71.1.tgz",
-      "integrity": "sha512-ZDhL6hvekeKDkZ1wUj6wN0thrB/7wOO8HaQoagk+pKaHoa0Py7OLR/m9mQM8S13mZpUQduNsznmXV1fOss4GOg==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.74.1.tgz",
+      "integrity": "sha512-DgaxdgdI6hl8X4cCR0C/8ksGgzA9asvJE3JEZqqmli+cg3QO8om2q3qkJi+3HLuhT3qAzWlGJwlvxm2L5toR3A==",
       "optional": true
     },
     "sass-embedded-win32-x64": {
-      "version": "1.71.1",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.71.1.tgz",
-      "integrity": "sha512-ecWP1TFUA9ujOuOTJfWC1iZsSZOdQy5OxIEHqoERxunyjwzkiTxfN8J7Y4bNQ5uwb4K0brxWyIM8Fq+UgDqcZA==",
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.74.1.tgz",
+      "integrity": "sha512-4FXBj73rWlzOXQMBtl58F2qjXD2hdO33ozQlY2AviiJfAhdh4lxsuusDn1rLH0ECzoDsIdbDGQdhZ5/n3C8djQ==",
       "optional": true
     },
     "semver": {
@@ -9294,9 +9319,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "source-map-resolve": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/uswds/uswds-compile#readme",
   "dependencies": {
-    "autoprefixer": "10.4.18",
+    "autoprefixer": "10.4.19",
     "del": "6.1.1",
     "gulp": "4.0.2",
     "gulp-postcss": "9.0.1",
@@ -33,9 +33,9 @@
     "gulp-sass": "5.1.0",
     "gulp-sourcemaps": "3.0.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "8.4.35",
+    "postcss": "^8.4.38",
     "postcss-csso": "6.0.1",
-    "sass-embedded": "1.71.1"
+    "sass-embedded": "1.74.1"
   },
   "devDependencies": {
     "@uswds/uswds": "^3.8.0",


### PR DESCRIPTION
# Summary

Updated non-vulnerable dependencies including the USWDS package.

## Testing instructions

1. Install this branch on site
  - On Site's `main` branch, run `
2. Run gulp scripts and ensure compile runs as expected without error.

## Dependency updates

| Dependency | Old version | New version |
|--------|--------|--------|
| `autoprefixer` | 10.4.18 | 10.4.19 |
| `postcss` | 8.4.35 | 8.4.38 | 
| `sass-embedded` | 1.71.1 | 1.74.1 | 