### PR TITLE
USWDS-Compile: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ _Provide a one or two sentence summary of the update that can be used in the rel
 <!--
 A successful summary is written in the past tense and includes:
 **A benefit statement.** A description of the update.
-See [USWDS-compille release notes](https://github.com/uswds/uswds-compile/releases) for examples.
+See [USWDS-compile release notes](https://github.com/uswds/uswds-compile/releases) for examples.
 -->
 
 ## Related issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,85 @@
+<!---
+Welcome! Thank you for contributing to the U.S. Web Design System.
+Your contributions are vital to our success and we are glad you're here.
+
+Please keep in mind:
+- This pull request (PR) template exists to help speed up integration.
+  The USWDS Core team reviews and approves every PR
+  before merging it into the public code base,
+  so the better we can understand the problem and solution,
+  the sooner we can merge this change.
+  The point here is: clear explanations matter!
+
+- You can erase any part of this template
+  that doesn't apply to your pull request (including these instructions!).
+
+- You can find more information about contributing in
+  [contributing.md](https://github.com/uswds/uswds-compile/blob/develop/CONTRIBUTING.md)
+  or you can reach out to us directly at uswds@gsa.gov.
+ -->
+
+<!---
+Step 1 - Title this PR with the following format:
+USWDS-Compile: [Brief statement describing what this pull request solves]
+e.g., "USWDS-Compile: Update Gulp to version 5"
+ -->
+
+# Summary
+
+_Provide a one or two sentence summary of the update that can be used in the release notes._
+<!--
+A successful summary is written in the past tense and includes:
+**A benefit statement.** A description of the update.
+See [USWDS-compille release notes](https://github.com/uswds/uswds-compile/releases) for examples.
+-->
+
+## Related issue
+
+Closes #_[issue_no]_
+<!--
+Every pull request should resolve an open issue.
+If no open issue exists, you can open one here:
+https://github.com/uswds/uswds-compile/issues.
+-->
+
+## Problem statement
+
+_Summarize the problem this PR solves in a clear and concise statement._
+<!--
+A successful problem statement conveys:
+1. The desired state,
+2. The actual state, and
+3. Consequences of remaining in the current state
+   (who does this affect and to what degree?)
+-->
+
+## Solution
+
+_Provide a summary of the solution this PR offers._
+<!--
+It can be helpful if we understand:
+1. What the solution is,
+2. Why this approach was chosen,
+3. How you implemented the change, and
+4. Possible limitations of this approach and alternate solution paths.
+-->
+
+## Testing and review
+
+_Share recommended methods for reviewing this change._
+<!--
+1. Describe the tests that you ran to verify your changes,
+2. Provide instructions to reproduce these tests, and
+3. Clarify the type of feedback you are looking for at this phase.
+-->
+
+## Dependency updates
+
+_List dependency updates in a table._
+<!--
+| Dependency name              | Previous version | New version |
+| ---------------------------- | :--------------: | :---------: |
+| [Updated dependency example] |     [1.0.0]      |   [1.0.1]   |
+| [New dependency example]     |        --        |   [3.0.1]   |
+| [Removed dependency example] |     [2.10.2]     |     --      |
+-->


### PR DESCRIPTION
# Summary

Added a PR template to the uswds-compile repo. 

> [!Note]
> The snyk errors in this PR should be resolved when we update to Gulp 5 in PR #96 

## Related issue

Closes #93

## Preview link
[PR template in preview mode](https://github.com/uswds/uswds-compile/blob/ef36af5e96df8abc542dae2bf1a24a8d6c56ee4a/.github/PULL_REQUEST_TEMPLATE.md)

## Testing and review
- Confirm that the structure and content of the PR template makes sense for the repo
- Confirm that the PR template is in the [right location](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template) in the `.github` directory
