### PR TITLE
USWDS-Compile - POAM: July '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "gulp-sass": "5.1.0",
         "gulp-sourcemaps": "3.0.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "^8.4.38",
+        "postcss": "^8.4.39",
         "postcss-csso": "6.0.1",
         "sass-embedded": "1.77.5"
       },
@@ -3680,9 +3680,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3699,7 +3699,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "gulp-sass": "5.1.0",
     "gulp-sourcemaps": "3.0.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "^8.4.38",
+    "postcss": "^8.4.39",
     "postcss-csso": "6.0.1",
     "sass-embedded": "1.77.5"
   },


### PR DESCRIPTION
# Summary

POAM for July 2024.

## Vulnerabilities

No changes in vulnerabilities

```node
3 moderate severity vulnerabilities
```

## Testing instructions

1. Install this branch on site
    - On Site's `main` branch, run: 
  ```bash
npm install "https://github.com/uswds/uswds-compile/tree/cm-POAM-july-2024" --save
```
2. Run gulp sass scripts and ensure compile runs as expected without error.
3. Ensure no regressions when package is used to compile site

## Dependency updates

| Dependency name | Previous version | Updated version |
|--------|--------|--------|
| postcss | ^8.4.38  | ^8.4.39 | 


