### PR TITLE
USWDS-Compile - POAM: August '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "autoprefixer": "10.4.19",
+        "autoprefixer": "10.4.20",
         "del": "6.1.1",
         "gulp": "5.0.0",
         "gulp-postcss": "9.0.1",
@@ -17,9 +17,9 @@
         "gulp-replace": "1.1.4",
         "gulp-sass": "5.1.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "^8.4.39",
+        "postcss": "^8.4.40",
         "postcss-csso": "6.0.1",
-        "sass-embedded": "1.77.5"
+        "sass-embedded": "1.77.8"
       },
       "devDependencies": {
         "@uswds/uswds": "^3.8.1",
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.19",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
-      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "funding": [
         {
           "type": "opencollective",
@@ -286,11 +286,11 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001599",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -422,9 +422,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -440,10 +440,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -481,9 +481,9 @@
       "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg=="
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001632",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-      "integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+      "version": "1.0.30001649",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
+      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -846,9 +846,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.796",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.796.tgz",
-      "integrity": "sha512-NglN/xprcM+SHD2XCli4oC6bWe6kHoytcyLKCWXmRL854F0qhPhaYgUswUsglnPxYaNQIg2uMY4BvaomIf3kLA=="
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
+      "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA=="
     },
     "node_modules/element-closest": {
       "version": "2.0.2",
@@ -1772,9 +1772,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -2026,9 +2026,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
-      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
+      "version": "8.4.40",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+      "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -2326,9 +2326,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass-embedded": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.5.tgz",
-      "integrity": "sha512-JQI8aprHDRSNK5exXsbusswTENQPJxW1QWUcLdwuyESoJClT1zo8e+4cmaV5OAU4abcRC6Av4/RmLocPdjcR3A==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.8.tgz",
+      "integrity": "sha512-WGXA6jcaoBo5Uhw0HX/s6z/sl3zyYQ7ZOnLOJzqwpctFcFmU4L07zn51e2VSkXXFpQZFAdMZNqOGz/7h/fvcRA==",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -2341,29 +2341,29 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.77.5",
-        "sass-embedded-android-arm64": "1.77.5",
-        "sass-embedded-android-ia32": "1.77.5",
-        "sass-embedded-android-x64": "1.77.5",
-        "sass-embedded-darwin-arm64": "1.77.5",
-        "sass-embedded-darwin-x64": "1.77.5",
-        "sass-embedded-linux-arm": "1.77.5",
-        "sass-embedded-linux-arm64": "1.77.5",
-        "sass-embedded-linux-ia32": "1.77.5",
-        "sass-embedded-linux-musl-arm": "1.77.5",
-        "sass-embedded-linux-musl-arm64": "1.77.5",
-        "sass-embedded-linux-musl-ia32": "1.77.5",
-        "sass-embedded-linux-musl-x64": "1.77.5",
-        "sass-embedded-linux-x64": "1.77.5",
-        "sass-embedded-win32-arm64": "1.77.5",
-        "sass-embedded-win32-ia32": "1.77.5",
-        "sass-embedded-win32-x64": "1.77.5"
+        "sass-embedded-android-arm": "1.77.8",
+        "sass-embedded-android-arm64": "1.77.8",
+        "sass-embedded-android-ia32": "1.77.8",
+        "sass-embedded-android-x64": "1.77.8",
+        "sass-embedded-darwin-arm64": "1.77.8",
+        "sass-embedded-darwin-x64": "1.77.8",
+        "sass-embedded-linux-arm": "1.77.8",
+        "sass-embedded-linux-arm64": "1.77.8",
+        "sass-embedded-linux-ia32": "1.77.8",
+        "sass-embedded-linux-musl-arm": "1.77.8",
+        "sass-embedded-linux-musl-arm64": "1.77.8",
+        "sass-embedded-linux-musl-ia32": "1.77.8",
+        "sass-embedded-linux-musl-x64": "1.77.8",
+        "sass-embedded-linux-x64": "1.77.8",
+        "sass-embedded-win32-arm64": "1.77.8",
+        "sass-embedded-win32-ia32": "1.77.8",
+        "sass-embedded-win32-x64": "1.77.8"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.5.tgz",
-      "integrity": "sha512-/DfNYoykqwMFduecqa8n0NH+cS6oLdCPFjwhe92efsOOt5WDYEOlolnhoOENZxqdzvSV+8axL+mHQ1Ypl4MLtg==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.8.tgz",
+      "integrity": "sha512-GpGL7xZ7V1XpFbnflib/NWbM0euRzineK0iwoo31/ntWKAXGj03iHhGzkSiOwWSFcXgsJJi3eRA5BTmBvK5Q+w==",
       "cpu": [
         "arm"
       ],
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.5.tgz",
-      "integrity": "sha512-t4yIhK5OUpg1coZxFpDo3BhI2YVj21JxEd5SVI6FfcWD2ESroQWsC4cbq3ejw5aun8R1Kx6xH1EKxO8bSMvn1g==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.8.tgz",
+      "integrity": "sha512-EmWHLbEx0Zo/f/lTFzMeH2Du+/I4RmSRlEnERSUKQWVp3aBSO04QDvdxfFezgQ+2Yt/ub9WMqBpma9P/8MPsLg==",
       "cpu": [
         "arm64"
       ],
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.5.tgz",
-      "integrity": "sha512-92dWhEbR0Z2kpjbpfOx4LM9wlNBSnDsRtwpkMUK8udQIE7uF3E4/Fsf/88IJk0MrRkk4iwrsxxiCb1bz2tWnHQ==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.8.tgz",
+      "integrity": "sha512-+GjfJ3lDezPi4dUUyjQBxlNKXNa+XVWsExtGvVNkv1uKyaOxULJhubVo2G6QTJJU0esJdfeXf5Ca5/J0ph7+7w==",
       "cpu": [
         "ia32"
       ],
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.5.tgz",
-      "integrity": "sha512-lFnXz9lRnjRLJ8Y28ONJViID3rDq4p6LJ/9ByPk2ZnSpx5ouUjsu4AfrXKJ0jgHWBaDvSKSxq2fPpt5aMQAEZA==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.8.tgz",
+      "integrity": "sha512-YZbFDzGe5NhaMCygShqkeCWtzjhkWxGVunc7ULR97wmxYPQLPeVyx7XFQZc84Aj0lKAJBJS4qRZeqphMqZEJsQ==",
       "cpu": [
         "x64"
       ],
@@ -2433,9 +2433,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.5.tgz",
-      "integrity": "sha512-J3yP6w+xqPrGQE0+sO4Gam6kBDJL5ivgkFNxR0fVlvKeN5qVFYhymp/xGRRMxBrKjohEQtBGP431EzrtvUMFow==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.8.tgz",
+      "integrity": "sha512-aifgeVRNE+i43toIkDFFJc/aPLMo0PJ5s5hKb52U+oNdiJE36n65n2L8F/8z3zZRvCa6eYtFY2b7f1QXR3B0LA==",
       "cpu": [
         "arm64"
       ],
@@ -2451,9 +2451,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.5.tgz",
-      "integrity": "sha512-A9fh5tg4s0FidMTG31Vs8TzYZ3Mam/I/tfqvN0g512OhBajp/p2DJvBY+0Br2r+TNH1yGUXf2ZfULuTBFj5u8w==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.8.tgz",
+      "integrity": "sha512-/VWZQtcWIOek60Zj6Sxk6HebXA1Qyyt3sD8o5qwbTgZnKitB1iEBuNunyGoAgMNeUz2PRd6rVki6hvbas9hQ6w==",
       "cpu": [
         "x64"
       ],
@@ -2469,9 +2469,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.5.tgz",
-      "integrity": "sha512-O7gbOWJloxITBZNkpwChFltxofsnDUf+3pz7+q2ETQKvZQ3kUfFENAF37slo0bsHJ7IEpwJK3ZJlnhZvIgfhgw==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.8.tgz",
+      "integrity": "sha512-2edZMB6jf0whx3T0zlgH+p131kOEmWp+I4wnKj7ZMUeokiY4Up05d10hSvb0Q63lOrSjFAWu6P5/pcYUUx8arQ==",
       "cpu": [
         "arm"
       ],
@@ -2487,9 +2487,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.5.tgz",
-      "integrity": "sha512-LoN804X7QsyvT/h8UGcgBMfV1SdT4JRRNV+slBICxoXPKBLXbZm9KyLRCBQcMLLdlXSZdOfZilxUN1Bd2az6OA==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.8.tgz",
+      "integrity": "sha512-6iIOIZtBFa2YfMsHqOb3qake3C9d/zlKxjooKKnTSo+6g6z+CLTzMXe1bOfayb7yxeenElmFoK1k54kWD/40+g==",
       "cpu": [
         "arm64"
       ],
@@ -2505,9 +2505,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.5.tgz",
-      "integrity": "sha512-KHNJymlEmjyJbhGfB34zowohjgMvv/qKVsDX5hPlar+qMh+cxJwfgPln1Zl9bfe9qLObmEV2zFA1rpVBWy4xGQ==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.8.tgz",
+      "integrity": "sha512-63GsFFHWN5yRLTWiSef32TM/XmjhCBx1DFhoqxmj+Yc6L9Z1h0lDHjjwdG6Sp5XTz5EmsaFKjpDgnQTP9hJX3Q==",
       "cpu": [
         "ia32"
       ],
@@ -2523,9 +2523,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.5.tgz",
-      "integrity": "sha512-TLhJzd1TJ0oX1oULobkWLMDLeErD27WbhdZqxtFvIqzyO+1TZPMwojhRX4YNWmHdmmYhIuXTR9foWxwL3Xjgsg==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.8.tgz",
+      "integrity": "sha512-nFkhSl3uu9btubm+JBW7uRglNVJ8W8dGfzVqh3fyQJKS1oyBC3vT3VOtfbT9YivXk28wXscSHpqXZwY7bUuopA==",
       "cpu": [
         "arm"
       ],
@@ -2538,9 +2538,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.5.tgz",
-      "integrity": "sha512-ZWl8K8rCL4/phm3IPWDADwjnYAiohoaKg7BKjGo+36zv8P0ocoA0A3j4xx7/kjUJWagOmmoTyYxoOu+lo1NaKw==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.8.tgz",
+      "integrity": "sha512-j8cgQxNWecYK+aH8ESFsyam/Q6G+9gg8eJegiRVpA9x8yk3ykfHC7UdQWwUcF22ZcuY4zegrjJx8k+thsgsOVA==",
       "cpu": [
         "arm64"
       ],
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.5.tgz",
-      "integrity": "sha512-83zNSgsIIc+tYQFKepFIlvAvAHnbWSpZ824MjqXJLeCbfzcMO8SZ/q6OA0Zd2SIrf79lCWI4OfPHqp1PI6M7HQ==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.8.tgz",
+      "integrity": "sha512-oWveMe+8TFlP8WBWPna/+Ec5TV0CE+PxEutyi0ltSruBds2zxRq9dPVOqrpPcDN9QUx50vNZC0Afgch0aQEd0g==",
       "cpu": [
         "ia32"
       ],
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.5.tgz",
-      "integrity": "sha512-/SW9ggXZJilbRbKvRHAxEuQM6Yr9piEpvK7/aDevFL2XFvBW9x+dTzpH5jPVEmM0qWdJisS1r5mEv8AXUUdQZg==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.8.tgz",
+      "integrity": "sha512-2NtRpMXHeFo9kaYxuZ+Ewwo39CE7BTS2JDfXkTjZTZqd8H+8KC53eBh516YQnn2oiqxSiKxm7a6pxbxGZGwXOQ==",
       "cpu": [
         "x64"
       ],
@@ -2583,9 +2583,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.5.tgz",
-      "integrity": "sha512-3EmYeY+K8nMwIy1El9C+mPuONMQyXSCD6Yyztn3G7moPdZTqXrTL7kTJIl+SRq1tCcnOMMGXnBRE7Kpou1wd+w==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.8.tgz",
+      "integrity": "sha512-ND5qZLWUCpOn7LJfOf0gLSZUWhNIysY+7NZK1Ctq+pM6tpJky3JM5I1jSMplNxv5H3o8p80n0gSm+fcjsEFfjQ==",
       "cpu": [
         "x64"
       ],
@@ -2601,9 +2601,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.5.tgz",
-      "integrity": "sha512-dwVFOqkyfCRQgQB8CByH+MG93fp7IsfFaPDDCQVzVFAT00+HXk/dWFPMnv65XDDndGwsUE1KlZnjg8iOBDlRdw==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.8.tgz",
+      "integrity": "sha512-7L8zT6xzEvTYj86MvUWnbkWYCNQP+74HvruLILmiPPE+TCgOjgdi750709BtppVJGGZSs40ZuN6mi/YQyGtwXg==",
       "cpu": [
         "arm64"
       ],
@@ -2619,9 +2619,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.5.tgz",
-      "integrity": "sha512-1ij/K5d2sHPJkytWiPJLoUOVHJOB6cSWXq7jmedeuGooWnBmqnWycmGkhBAEK/t6t1XgzMPsiJMGiHKh7fnBuA==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.8.tgz",
+      "integrity": "sha512-7Buh+4bP0WyYn6XPbthkIa3M2vtcR8QIsFVg3JElVlr+8Ng19jqe0t0SwggDgbMX6AdQZC+Wj4F1BprZSok42A==",
       "cpu": [
         "ia32"
       ],
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.77.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.5.tgz",
-      "integrity": "sha512-Pn6j0jDGeEAhuuVY0CaZaBa7yNkqimEsbUDYYuQ9xh+XdGvZ86SZf6HXHUVIyQUjHORLwQ5f0XoKYYzKfC0y9w==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.8.tgz",
+      "integrity": "sha512-rZmLIx4/LLQm+4GW39sRJW0MIlDqmyV0fkRzTmhFP5i/wVC7cuj8TUubPHw18rv2rkHFfBZKZJTCkPjCS5Z+SA==",
       "cpu": [
         "x64"
       ],
@@ -2887,9 +2887,9 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/uswds/uswds-compile#readme",
   "dependencies": {
-    "autoprefixer": "10.4.19",
+    "autoprefixer": "10.4.20",
     "del": "6.1.1",
     "gulp": "5.0.0",
     "gulp-postcss": "9.0.1",
@@ -32,9 +32,9 @@
     "gulp-replace": "1.1.4",
     "gulp-sass": "5.1.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "^8.4.39",
+    "postcss": "^8.4.40",
     "postcss-csso": "6.0.1",
-    "sass-embedded": "1.77.5"
+    "sass-embedded": "1.77.8"
   },
   "devDependencies": {
     "@uswds/uswds": "^3.8.1",


### PR DESCRIPTION
# Summary

POAM dependency updates for August 2024.

## Vulnerabilities

No changes in vulnerabilities

```node
found 0 vulnerabilities
```

## Testing instructions

1. Install this branch on site
    - On Site's `main` branch, run: 
  ```bash
npm install "https://github.com/uswds/uswds-compile/tree/cm-POAM-august-2024" --save
```
2. Run gulp sass scripts and ensure compile runs as expected without error.
3. Ensure no regressions when package is used to compile site

## Dependency updates

| Dependency name | Previous version | Updated version |
|--------|--------|--------|
| autoprefixer | 10.4.19  | 10.4.20 | 
| postcss | ^8.4.39  | ^8.4.40 | 
| sass-embedded | 1.77.5 | 1.77.8 |

