### PR TITLE
Update Gulp reference to `Gulp 5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USWDS Compile
 
-Simple [Gulp 4](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
+Simple [Gulp 5](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USWDS Compile
 
-Simple [Gulp 5](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
+Simple [Gulp 4](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USWDS Compile
 
-Simple [Gulp 4.0](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
+Simple [Gulp 5](https://gulpjs.com/) functions for copying USWDS static assets and transforming USWDS Sass into browser-readable CSS.
 
 ## Requirements
 


### PR DESCRIPTION
This updates the README to reference Gulp 5 and not Gulp 4. We'll also need to update the repo description in the GH interface after we publish.

Note that I'd like us to use `Gulp 5` and not `Gulp 5.0` so we're not getting overspecific. We' don't want to have to update the version number in the README with every version bump.