### PR TITLE
USWDS-Compile - POAM: September '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,12 @@
         "gulp-replace": "1.1.4",
         "gulp-sass": "5.1.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "8.4.40",
+        "postcss": "8.4.45",
         "postcss-csso": "6.0.1",
-        "sass-embedded": "1.77.8"
+        "sass-embedded": "1.78.0"
       },
       "devDependencies": {
-        "@uswds/uswds": "^3.8.1",
+        "@uswds/uswds": "^3.8.2",
         "uswds": "^2.14.0"
       }
     },
@@ -105,12 +105,12 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.1.tgz",
-      "integrity": "sha512-bKG/B9mJF1v0yoqth48wQDzST5Xyu3OxxpePIPDyhKWS84oDrCehnu3Z88JhSjdIAJMl8dtjtH8YvdO9kZUpAg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.2.tgz",
+      "integrity": "sha512-8sTx/GqlbTwSIK+0AFOGrYdaW1rKVB7Bp0+v9AMVt3I5vPK7CL0+I6vlclSf3U7ysJZeTTdkNS8q89sIAeL+AA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",
         "receptor": "1.0.0",
         "resolve-id-refs": "0.1.0"
@@ -2026,9 +2026,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.40",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
-      "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
+      "version": "8.4.45",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
+      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -2043,6 +2043,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.1",
@@ -2326,9 +2327,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass-embedded": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.8.tgz",
-      "integrity": "sha512-WGXA6jcaoBo5Uhw0HX/s6z/sl3zyYQ7ZOnLOJzqwpctFcFmU4L07zn51e2VSkXXFpQZFAdMZNqOGz/7h/fvcRA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.78.0.tgz",
+      "integrity": "sha512-NR2kvhWVFABmBm0AqgFw9OweQycs0Qs+/teJ9Su+BUY7up+f8S5F/Zi+7QtAqJlewsQyUNfzm1vRuM+20lBwRQ==",
+      "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "buffer-builder": "^0.2.0",
@@ -2337,198 +2339,203 @@
         "supports-color": "^8.1.1",
         "varint": "^6.0.0"
       },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
       "engines": {
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.77.8",
-        "sass-embedded-android-arm64": "1.77.8",
-        "sass-embedded-android-ia32": "1.77.8",
-        "sass-embedded-android-x64": "1.77.8",
-        "sass-embedded-darwin-arm64": "1.77.8",
-        "sass-embedded-darwin-x64": "1.77.8",
-        "sass-embedded-linux-arm": "1.77.8",
-        "sass-embedded-linux-arm64": "1.77.8",
-        "sass-embedded-linux-ia32": "1.77.8",
-        "sass-embedded-linux-musl-arm": "1.77.8",
-        "sass-embedded-linux-musl-arm64": "1.77.8",
-        "sass-embedded-linux-musl-ia32": "1.77.8",
-        "sass-embedded-linux-musl-x64": "1.77.8",
-        "sass-embedded-linux-x64": "1.77.8",
-        "sass-embedded-win32-arm64": "1.77.8",
-        "sass-embedded-win32-ia32": "1.77.8",
-        "sass-embedded-win32-x64": "1.77.8"
+        "sass-embedded-android-arm": "1.78.0",
+        "sass-embedded-android-arm64": "1.78.0",
+        "sass-embedded-android-ia32": "1.78.0",
+        "sass-embedded-android-riscv64": "1.78.0",
+        "sass-embedded-android-x64": "1.78.0",
+        "sass-embedded-darwin-arm64": "1.78.0",
+        "sass-embedded-darwin-x64": "1.78.0",
+        "sass-embedded-linux-arm": "1.78.0",
+        "sass-embedded-linux-arm64": "1.78.0",
+        "sass-embedded-linux-ia32": "1.78.0",
+        "sass-embedded-linux-musl-arm": "1.78.0",
+        "sass-embedded-linux-musl-arm64": "1.78.0",
+        "sass-embedded-linux-musl-ia32": "1.78.0",
+        "sass-embedded-linux-musl-riscv64": "1.78.0",
+        "sass-embedded-linux-musl-x64": "1.78.0",
+        "sass-embedded-linux-riscv64": "1.78.0",
+        "sass-embedded-linux-x64": "1.78.0",
+        "sass-embedded-win32-arm64": "1.78.0",
+        "sass-embedded-win32-ia32": "1.78.0",
+        "sass-embedded-win32-x64": "1.78.0"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.8.tgz",
-      "integrity": "sha512-GpGL7xZ7V1XpFbnflib/NWbM0euRzineK0iwoo31/ntWKAXGj03iHhGzkSiOwWSFcXgsJJi3eRA5BTmBvK5Q+w==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.78.0.tgz",
+      "integrity": "sha512-YM6nrmKsj+ImaSTd96F+jzbWSbhPkRN4kedbLgIJ5FsILNa9NAqhmrCQz9pdcjuAhyfxWImdUACsT23CPGENZQ==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.8.tgz",
-      "integrity": "sha512-EmWHLbEx0Zo/f/lTFzMeH2Du+/I4RmSRlEnERSUKQWVp3aBSO04QDvdxfFezgQ+2Yt/ub9WMqBpma9P/8MPsLg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.78.0.tgz",
+      "integrity": "sha512-2sAr11EgwPudAuyk4Ite+fWGYJspiFSiZDU2D8/vjjI7BaB9FG6ksYqww3svoMMnjPUWBCjKPDELpZTxViLJbw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.8.tgz",
-      "integrity": "sha512-+GjfJ3lDezPi4dUUyjQBxlNKXNa+XVWsExtGvVNkv1uKyaOxULJhubVo2G6QTJJU0esJdfeXf5Ca5/J0ph7+7w==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.78.0.tgz",
+      "integrity": "sha512-TyJOo4TgnHpOfC/PfqCBqd+jGRanWoRd4Br/0KAfIvaIFjTGIPdk26vUyDVugV1J8QUEY4INGE8EXAuDeRldUQ==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.78.0.tgz",
+      "integrity": "sha512-wwajpsVRuhb7ixrkA3Yu60V2LtROYn45PIYeda30/MrMJi9k3xEqHLhodTexFm6wZoKclGSDZ6L9U5q0XyRKiQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.8.tgz",
-      "integrity": "sha512-YZbFDzGe5NhaMCygShqkeCWtzjhkWxGVunc7ULR97wmxYPQLPeVyx7XFQZc84Aj0lKAJBJS4qRZeqphMqZEJsQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.78.0.tgz",
+      "integrity": "sha512-k5l66PO0LgSHMDbDzAQ/vqrXMlJ3r42ZHJA8MJvUbA6sQxTzDS381V7L+EhOATwyI225j2FhEeTHW6rr4WBQzA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.8.tgz",
-      "integrity": "sha512-aifgeVRNE+i43toIkDFFJc/aPLMo0PJ5s5hKb52U+oNdiJE36n65n2L8F/8z3zZRvCa6eYtFY2b7f1QXR3B0LA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.78.0.tgz",
+      "integrity": "sha512-3JaxceFSR6N+a22hPYYkj1p45eBaWTt/M8MPTbfzU3TGZrU9bmRX7WlUVtXTo1yYI2iMf22nCv0PQ5ExFF3FMQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.8.tgz",
-      "integrity": "sha512-/VWZQtcWIOek60Zj6Sxk6HebXA1Qyyt3sD8o5qwbTgZnKitB1iEBuNunyGoAgMNeUz2PRd6rVki6hvbas9hQ6w==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.78.0.tgz",
+      "integrity": "sha512-UMTijqE3fJ8vEaaD7GPG7G3GsHuPKOdpS8vuA2v2uwO3BPFp/rEKah66atvGqvGO+0JYApkSv0YTnnexSrkHIQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.8.tgz",
-      "integrity": "sha512-2edZMB6jf0whx3T0zlgH+p131kOEmWp+I4wnKj7ZMUeokiY4Up05d10hSvb0Q63lOrSjFAWu6P5/pcYUUx8arQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.78.0.tgz",
+      "integrity": "sha512-JafT+Co0RK8oO3g9TfVRuG7tkYeh35yDGTgqCFxLrktnkiw5pmIagCfpjxk5GBcSfJMOzhCgclTCDJWAuHGuMQ==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.8.tgz",
-      "integrity": "sha512-6iIOIZtBFa2YfMsHqOb3qake3C9d/zlKxjooKKnTSo+6g6z+CLTzMXe1bOfayb7yxeenElmFoK1k54kWD/40+g==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.78.0.tgz",
+      "integrity": "sha512-juMIMpp3DIAiQ842y+boqh0u2SjN4m3mDKrDfMuBznj8DSQoy9J/3e4hLh3g+p0/j83WuROu5nNoYxm2Xz8rww==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.8.tgz",
-      "integrity": "sha512-63GsFFHWN5yRLTWiSef32TM/XmjhCBx1DFhoqxmj+Yc6L9Z1h0lDHjjwdG6Sp5XTz5EmsaFKjpDgnQTP9hJX3Q==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.78.0.tgz",
+      "integrity": "sha512-Gy8GW5g6WX9t8CT2Dto5AL6ikB+pG7aAXWXvfu3RFHktixSwSbyy6CeGqSk1t0xyJCFkQQA/V8HU9bNdeHiBxg==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.8.tgz",
-      "integrity": "sha512-nFkhSl3uu9btubm+JBW7uRglNVJ8W8dGfzVqh3fyQJKS1oyBC3vT3VOtfbT9YivXk28wXscSHpqXZwY7bUuopA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.78.0.tgz",
+      "integrity": "sha512-DUVXtcsfsiOJ2Zwp4Y3T6KZWX8h0gWpzmFUrx+gSIbg67vV8Ww2DWMjWRwqLe7HOLTYBegMBYpMgMgZiPtXhIA==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2538,12 +2545,13 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.8.tgz",
-      "integrity": "sha512-j8cgQxNWecYK+aH8ESFsyam/Q6G+9gg8eJegiRVpA9x8yk3ykfHC7UdQWwUcF22ZcuY4zegrjJx8k+thsgsOVA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.78.0.tgz",
+      "integrity": "sha512-Lu/TlRHbe9aJY7B7PwWCJz7pTT5Rc50VkApWEmPiU/nu0mGbSpg0Xwar6pNeG8+98ubgKKdRb01N3bvclf5a4A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2553,12 +2561,29 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.8.tgz",
-      "integrity": "sha512-oWveMe+8TFlP8WBWPna/+Ec5TV0CE+PxEutyi0ltSruBds2zxRq9dPVOqrpPcDN9QUx50vNZC0Afgch0aQEd0g==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.78.0.tgz",
+      "integrity": "sha512-1E5ywUnq6MRPAecr2r/vDOBr93wXyculEmfyF5JRG8mUufMaxGIhfx64OQE6Drjs+EDURcYZ+Qcg6/ubJWqhcw==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.78.0.tgz",
+      "integrity": "sha512-YvQEvX7ctn5BwC79+HBagDYIciEkwcl2NLgoydmEsBO/0+ncMKSGnjsn/iRzErbq1KJNyjGEni8eSHlrtQI1vQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2568,12 +2593,29 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.8.tgz",
-      "integrity": "sha512-2NtRpMXHeFo9kaYxuZ+Ewwo39CE7BTS2JDfXkTjZTZqd8H+8KC53eBh516YQnn2oiqxSiKxm7a6pxbxGZGwXOQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.78.0.tgz",
+      "integrity": "sha512-azdUcZZvZmtUBslIKr2/l4aQrTX7BvO96TD0GLdWz9vuXZrokYm09AJZEnb5j6Pk5I4Xr0yM6BG1Vgcbzqi5Zg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.78.0.tgz",
+      "integrity": "sha512-g8M6vqHMjZUoH9C1WJsgwu+qmwdJAAMDaJTM1emeAScUZMTaQGzm+Q6C5oSGnAGR3XLT/drgbHhbmruXDgkdeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2583,73 +2625,65 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.8.tgz",
-      "integrity": "sha512-ND5qZLWUCpOn7LJfOf0gLSZUWhNIysY+7NZK1Ctq+pM6tpJky3JM5I1jSMplNxv5H3o8p80n0gSm+fcjsEFfjQ==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.78.0.tgz",
+      "integrity": "sha512-m997ThzpMwql4u6LzZCoHPIQkgK6bbLPLc7ydemo2Wusqzh6j8XAGxVT5oANp6s2Dmj+yh49pKDozal+tzEX9w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.8.tgz",
-      "integrity": "sha512-7L8zT6xzEvTYj86MvUWnbkWYCNQP+74HvruLILmiPPE+TCgOjgdi750709BtppVJGGZSs40ZuN6mi/YQyGtwXg==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.78.0.tgz",
+      "integrity": "sha512-qTLIIC5URYRmeuYYllfoL0K1cHSUd+f3sFHAA6fjtdgf288usd6ToCbWpuFb0BtVceEfGQX8lEp+teOG7n7Quw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.8.tgz",
-      "integrity": "sha512-7Buh+4bP0WyYn6XPbthkIa3M2vtcR8QIsFVg3JElVlr+8Ng19jqe0t0SwggDgbMX6AdQZC+Wj4F1BprZSok42A==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.78.0.tgz",
+      "integrity": "sha512-BrOWh18T6Y9xgCokGXElEnd8j03fO4W83bwJ9wHRRkrQWaeHtHs3XWW0fX1j2brngWUTjU+jcYUijWF1Z60krw==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.8.tgz",
-      "integrity": "sha512-rZmLIx4/LLQm+4GW39sRJW0MIlDqmyV0fkRzTmhFP5i/wVC7cuj8TUubPHw18rv2rkHFfBZKZJTCkPjCS5Z+SA==",
+      "version": "1.78.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.78.0.tgz",
+      "integrity": "sha512-C14iFDJd7oGhmQehRiEL7GtzMmLwubcDqsBarQ+u9LbHoDlUQfIPd7y8mVtNgtxJCdrAO/jc5qR4C+85yE3xPQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "gulp-replace": "1.1.4",
     "gulp-sass": "5.1.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "8.4.40",
+    "postcss": "8.4.45",
     "postcss-csso": "6.0.1",
-    "sass-embedded": "1.77.8"
+    "sass-embedded": "1.78.0"
   },
   "devDependencies": {
-    "@uswds/uswds": "^3.8.1",
+    "@uswds/uswds": "^3.8.2",
     "uswds": "^2.14.0"
   },
   "overrides": {


### PR DESCRIPTION
# Summary

POAM dependency updates for September 2024.

## Vulnerabilities

No changes in vulnerabilities

```node
found 0 vulnerabilities
```

## Testing instructions

1. Install this branch on site
    - On Site's `main` branch, run: 
  ```bash
npm install "https://github.com/uswds/uswds-compile/tree/cm-POAM-september-2024" --save
```
2. Run gulp build scripts and ensure compile runs as expected without error.
3. Ensure no regressions when package is used to compile site

## Dependency updates

| Dependency name | Old version | New version |
| --- | --- | --- |
| @uswds/uswds | ^3.8.1 | ^3.8.2 |
| postcss | 8.4.40 | 8.4.45 |
| sass-embedded | 1.77.8 | 1.78.0 |



