### PR TITLE
USWDS-Compile - POAM: October '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,19 +17,20 @@
         "gulp-replace": "1.1.4",
         "gulp-sass": "5.1.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "8.4.45",
+        "postcss": "8.4.47",
         "postcss-csso": "6.0.1",
-        "sass-embedded": "1.78.0"
+        "sass-embedded": "1.79.4"
       },
       "devDependencies": {
-        "@uswds/uswds": "^3.8.2",
+        "@uswds/uswds": "^3.9.0",
         "uswds": "^2.14.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
-      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.0.tgz",
+      "integrity": "sha512-+imAQkHf7U/Rwvu0wk1XWgsP3WnpCWmK7B48f0XqSNzgk64+grljTKC7pnO/xBiEMUziF7vKRfbBnOQhg126qQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@gulpjs/messages": {
       "version": "1.1.0",
@@ -105,9 +106,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.2.tgz",
-      "integrity": "sha512-8sTx/GqlbTwSIK+0AFOGrYdaW1rKVB7Bp0+v9AMVt3I5vPK7CL0+I6vlclSf3U7ysJZeTTdkNS8q89sIAeL+AA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.9.0.tgz",
+      "integrity": "sha512-8THm36j7iLjrDiI1D0C6b3hHsmM/Sy5Iiz+IjE+i/gYzVUMG9XVthxAZYonhU97Q1b079n6nYwlUmDSYowJecQ==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
@@ -662,6 +663,12 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1962,9 +1969,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2026,9 +2034,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.45",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.45.tgz",
-      "integrity": "sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2046,8 +2054,8 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -2327,13 +2335,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass-embedded": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.78.0.tgz",
-      "integrity": "sha512-NR2kvhWVFABmBm0AqgFw9OweQycs0Qs+/teJ9Su+BUY7up+f8S5F/Zi+7QtAqJlewsQyUNfzm1vRuM+20lBwRQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.79.4.tgz",
+      "integrity": "sha512-3AATrtStMgxYjkit02/Ix8vx/P7qderYG6DHjmehfk5jiw53OaWVScmcGJSwp/d77kAkxDQ+Y0r+79VynGmrkw==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^1.0.0",
+        "@bufbuild/protobuf": "^2.0.0",
         "buffer-builder": "^0.2.0",
+        "colorjs.io": "^0.5.0",
         "immutable": "^4.0.0",
         "rxjs": "^7.4.0",
         "supports-color": "^8.1.1",
@@ -2346,32 +2355,32 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.78.0",
-        "sass-embedded-android-arm64": "1.78.0",
-        "sass-embedded-android-ia32": "1.78.0",
-        "sass-embedded-android-riscv64": "1.78.0",
-        "sass-embedded-android-x64": "1.78.0",
-        "sass-embedded-darwin-arm64": "1.78.0",
-        "sass-embedded-darwin-x64": "1.78.0",
-        "sass-embedded-linux-arm": "1.78.0",
-        "sass-embedded-linux-arm64": "1.78.0",
-        "sass-embedded-linux-ia32": "1.78.0",
-        "sass-embedded-linux-musl-arm": "1.78.0",
-        "sass-embedded-linux-musl-arm64": "1.78.0",
-        "sass-embedded-linux-musl-ia32": "1.78.0",
-        "sass-embedded-linux-musl-riscv64": "1.78.0",
-        "sass-embedded-linux-musl-x64": "1.78.0",
-        "sass-embedded-linux-riscv64": "1.78.0",
-        "sass-embedded-linux-x64": "1.78.0",
-        "sass-embedded-win32-arm64": "1.78.0",
-        "sass-embedded-win32-ia32": "1.78.0",
-        "sass-embedded-win32-x64": "1.78.0"
+        "sass-embedded-android-arm": "1.79.4",
+        "sass-embedded-android-arm64": "1.79.4",
+        "sass-embedded-android-ia32": "1.79.4",
+        "sass-embedded-android-riscv64": "1.79.4",
+        "sass-embedded-android-x64": "1.79.4",
+        "sass-embedded-darwin-arm64": "1.79.4",
+        "sass-embedded-darwin-x64": "1.79.4",
+        "sass-embedded-linux-arm": "1.79.4",
+        "sass-embedded-linux-arm64": "1.79.4",
+        "sass-embedded-linux-ia32": "1.79.4",
+        "sass-embedded-linux-musl-arm": "1.79.4",
+        "sass-embedded-linux-musl-arm64": "1.79.4",
+        "sass-embedded-linux-musl-ia32": "1.79.4",
+        "sass-embedded-linux-musl-riscv64": "1.79.4",
+        "sass-embedded-linux-musl-x64": "1.79.4",
+        "sass-embedded-linux-riscv64": "1.79.4",
+        "sass-embedded-linux-x64": "1.79.4",
+        "sass-embedded-win32-arm64": "1.79.4",
+        "sass-embedded-win32-ia32": "1.79.4",
+        "sass-embedded-win32-x64": "1.79.4"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.78.0.tgz",
-      "integrity": "sha512-YM6nrmKsj+ImaSTd96F+jzbWSbhPkRN4kedbLgIJ5FsILNa9NAqhmrCQz9pdcjuAhyfxWImdUACsT23CPGENZQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.79.4.tgz",
+      "integrity": "sha512-YOVpDGDcwWUQvktpJhYo4zOkknDpdX6ALpaeHDTX6GBUvnZfx+Widh76v+QFUhiJQ/I/hndXg1jv/PKilOHRrw==",
       "cpu": [
         "arm"
       ],
@@ -2385,9 +2394,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.78.0.tgz",
-      "integrity": "sha512-2sAr11EgwPudAuyk4Ite+fWGYJspiFSiZDU2D8/vjjI7BaB9FG6ksYqww3svoMMnjPUWBCjKPDELpZTxViLJbw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.79.4.tgz",
+      "integrity": "sha512-0JAZ8TtXYv9yI3Yasaq03xvo7DLJOmD+Exb30oJKxXcWTAV9TB0ZWKoIRsFxbCyPxyn7ouxkaCEXQtaTRKrmfw==",
       "cpu": [
         "arm64"
       ],
@@ -2401,9 +2410,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.78.0.tgz",
-      "integrity": "sha512-TyJOo4TgnHpOfC/PfqCBqd+jGRanWoRd4Br/0KAfIvaIFjTGIPdk26vUyDVugV1J8QUEY4INGE8EXAuDeRldUQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.79.4.tgz",
+      "integrity": "sha512-IjO3RoyvNN84ZyfAR5s/a8TIdNPfClb7CLGrswB3BN/NElYIJUJMVHD6+Y8W9QwBIZ8DrK1IdLFSTV8nn82xMA==",
       "cpu": [
         "ia32"
       ],
@@ -2417,9 +2426,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.78.0.tgz",
-      "integrity": "sha512-wwajpsVRuhb7ixrkA3Yu60V2LtROYn45PIYeda30/MrMJi9k3xEqHLhodTexFm6wZoKclGSDZ6L9U5q0XyRKiQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.79.4.tgz",
+      "integrity": "sha512-uOT8nXmKxSwuIdcqvElVWBFcm/+YcIvmwfoKbpuuSOSxUe9eqFzxo+fk7ILhynzf6FBlvRUH5DcjGj+sXtCc3w==",
       "cpu": [
         "riscv64"
       ],
@@ -2433,9 +2442,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.78.0.tgz",
-      "integrity": "sha512-k5l66PO0LgSHMDbDzAQ/vqrXMlJ3r42ZHJA8MJvUbA6sQxTzDS381V7L+EhOATwyI225j2FhEeTHW6rr4WBQzA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.79.4.tgz",
+      "integrity": "sha512-W2FQoj3Z2J2DirNs3xSBVvrhMuqLnsqvOPulxOkhL/074+faKOZZnPx2tZ5zsHbY97SonciiU0SV0mm98xI42w==",
       "cpu": [
         "x64"
       ],
@@ -2449,9 +2458,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.78.0.tgz",
-      "integrity": "sha512-3JaxceFSR6N+a22hPYYkj1p45eBaWTt/M8MPTbfzU3TGZrU9bmRX7WlUVtXTo1yYI2iMf22nCv0PQ5ExFF3FMQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.79.4.tgz",
+      "integrity": "sha512-pcYtbN1VUAAcfgyHeX8ySndDWGjIvcq6rldduktPbGGuAlEWFDfnwjTbv0hS945ggdzZ6TFnaFlLEDr0SjKzBA==",
       "cpu": [
         "arm64"
       ],
@@ -2465,9 +2474,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.78.0.tgz",
-      "integrity": "sha512-UMTijqE3fJ8vEaaD7GPG7G3GsHuPKOdpS8vuA2v2uwO3BPFp/rEKah66atvGqvGO+0JYApkSv0YTnnexSrkHIQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.79.4.tgz",
+      "integrity": "sha512-ir8CFTfc4JLx/qCP8LK1/3pWv35nRyAQkUK7lBIKM6hWzztt64gcno9rZIk4SpHr7Z/Bp1IYWWRS4ZT+4HmsbA==",
       "cpu": [
         "x64"
       ],
@@ -2481,9 +2490,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.78.0.tgz",
-      "integrity": "sha512-JafT+Co0RK8oO3g9TfVRuG7tkYeh35yDGTgqCFxLrktnkiw5pmIagCfpjxk5GBcSfJMOzhCgclTCDJWAuHGuMQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.79.4.tgz",
+      "integrity": "sha512-H/XEE3rY7c+tY0qDaELjPjC6VheAhBo1tPJQ6UHoBEf8xrbT/RT3dWiIS8grp9Vk54RCn05BEB/+POaljvvKGA==",
       "cpu": [
         "arm"
       ],
@@ -2497,9 +2506,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.78.0.tgz",
-      "integrity": "sha512-juMIMpp3DIAiQ842y+boqh0u2SjN4m3mDKrDfMuBznj8DSQoy9J/3e4hLh3g+p0/j83WuROu5nNoYxm2Xz8rww==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.79.4.tgz",
+      "integrity": "sha512-XIVn2mCuA422SR2kmKjF6jhjMs1Vrt1DbZ/ktSp+eR0sU4ugu2htg45GajiUFSKKRj7Sc+cBdThq1zPPsDLf1w==",
       "cpu": [
         "arm64"
       ],
@@ -2513,9 +2522,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.78.0.tgz",
-      "integrity": "sha512-Gy8GW5g6WX9t8CT2Dto5AL6ikB+pG7aAXWXvfu3RFHktixSwSbyy6CeGqSk1t0xyJCFkQQA/V8HU9bNdeHiBxg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.79.4.tgz",
+      "integrity": "sha512-3nqZxV4nuUTb1ahLexVl4hsnx1KKwiGdHEf1xHWTZai6fYFMcwyNPrHySCQzFHqb5xiqSpPzzrKjuDhF6+guuQ==",
       "cpu": [
         "ia32"
       ],
@@ -2529,9 +2538,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.78.0.tgz",
-      "integrity": "sha512-DUVXtcsfsiOJ2Zwp4Y3T6KZWX8h0gWpzmFUrx+gSIbg67vV8Ww2DWMjWRwqLe7HOLTYBegMBYpMgMgZiPtXhIA==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.79.4.tgz",
+      "integrity": "sha512-HnbU1DEiQdUayioNzxh2WlbTEgQRBPTgIIvof8J63QLmVItUqE7EkWYkSUy4RhO+8NsuN9wzGmGTzFBvTImU7g==",
       "cpu": [
         "arm"
       ],
@@ -2545,9 +2554,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.78.0.tgz",
-      "integrity": "sha512-Lu/TlRHbe9aJY7B7PwWCJz7pTT5Rc50VkApWEmPiU/nu0mGbSpg0Xwar6pNeG8+98ubgKKdRb01N3bvclf5a4A==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.79.4.tgz",
+      "integrity": "sha512-C6qX06waPEfDgOHR8jXoYxl0EtIXOyBDyyonrLO3StRjWjGx7XMQj2hA/KXSsV+Hr71fBOsaViosqWXPzTbEiQ==",
       "cpu": [
         "arm64"
       ],
@@ -2561,9 +2570,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.78.0.tgz",
-      "integrity": "sha512-1E5ywUnq6MRPAecr2r/vDOBr93wXyculEmfyF5JRG8mUufMaxGIhfx64OQE6Drjs+EDURcYZ+Qcg6/ubJWqhcw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.79.4.tgz",
+      "integrity": "sha512-y5b0fdOPWyhj4c+mc88GvQiC5onRH1V0iNaWNjsiZ+L4hHje6T98nDLrCJn0fz5GQnXjyLCLZduMWbfV0QjHGg==",
       "cpu": [
         "ia32"
       ],
@@ -2577,9 +2586,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.78.0.tgz",
-      "integrity": "sha512-YvQEvX7ctn5BwC79+HBagDYIciEkwcl2NLgoydmEsBO/0+ncMKSGnjsn/iRzErbq1KJNyjGEni8eSHlrtQI1vQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.79.4.tgz",
+      "integrity": "sha512-G2M5ADMV9SqnkwpM0S+UzDz7xR2njCOhofku/sDMZABzAjQQWTsAykKoGmzlT98fTw2HbNhb6u74umf2WLhCfw==",
       "cpu": [
         "riscv64"
       ],
@@ -2593,9 +2602,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.78.0.tgz",
-      "integrity": "sha512-azdUcZZvZmtUBslIKr2/l4aQrTX7BvO96TD0GLdWz9vuXZrokYm09AJZEnb5j6Pk5I4Xr0yM6BG1Vgcbzqi5Zg==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.79.4.tgz",
+      "integrity": "sha512-kQm8dCU3DXf7DtUGWYPiPs03KJYKvFeiZJHhSx993DCM8D2b0wCXWky0S0Z46gf1sEur0SN4Lvnt1WczTqxIBw==",
       "cpu": [
         "x64"
       ],
@@ -2609,9 +2618,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.78.0.tgz",
-      "integrity": "sha512-g8M6vqHMjZUoH9C1WJsgwu+qmwdJAAMDaJTM1emeAScUZMTaQGzm+Q6C5oSGnAGR3XLT/drgbHhbmruXDgkdeQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.79.4.tgz",
+      "integrity": "sha512-GaTI/mXYWYSzG5wxtM4H2cozLpATyh+4l+rO9FFKOL8e1sUOLAzTeRdU2nSBYCuRqsxRuTZIwCXhSz9Q3NRuNA==",
       "cpu": [
         "riscv64"
       ],
@@ -2625,9 +2634,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.78.0.tgz",
-      "integrity": "sha512-m997ThzpMwql4u6LzZCoHPIQkgK6bbLPLc7ydemo2Wusqzh6j8XAGxVT5oANp6s2Dmj+yh49pKDozal+tzEX9w==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.79.4.tgz",
+      "integrity": "sha512-f9laGkqHgC01h99Qt4LsOV+OLMffjvUcTu14hYWqMS9QVX5a4ihMwpf1NoAtTUytb7cVF3rYY/NVGuXt6G3ppQ==",
       "cpu": [
         "x64"
       ],
@@ -2641,9 +2650,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.78.0.tgz",
-      "integrity": "sha512-qTLIIC5URYRmeuYYllfoL0K1cHSUd+f3sFHAA6fjtdgf288usd6ToCbWpuFb0BtVceEfGQX8lEp+teOG7n7Quw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.79.4.tgz",
+      "integrity": "sha512-cidBvtaA2cJ6dNlwQEa8qak+ezypurzKs0h0QAHLH324+j/6Jum7LCnQhZRPYJBFjHl+WYd7KwzPnJ2X5USWnQ==",
       "cpu": [
         "arm64"
       ],
@@ -2657,9 +2666,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.78.0.tgz",
-      "integrity": "sha512-BrOWh18T6Y9xgCokGXElEnd8j03fO4W83bwJ9wHRRkrQWaeHtHs3XWW0fX1j2brngWUTjU+jcYUijWF1Z60krw==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.79.4.tgz",
+      "integrity": "sha512-hexdmNTIZGTKNTzlMcdvEXzYuxOJcY89zqgsf45aQ2YMy4y2M8dTOxRI/Vz7p4iRxVp1Jow6LCtaLHrNI2Ordg==",
       "cpu": [
         "ia32"
       ],
@@ -2673,9 +2682,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.78.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.78.0.tgz",
-      "integrity": "sha512-C14iFDJd7oGhmQehRiEL7GtzMmLwubcDqsBarQ+u9LbHoDlUQfIPd7y8mVtNgtxJCdrAO/jc5qR4C+85yE3xPQ==",
+      "version": "1.79.4",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.79.4.tgz",
+      "integrity": "sha512-73yrpiWIbti6DkxhWURklkgSLYKfU9itDmvHxB+oYSb4vQveIApqTwSyTOuIUb/6Da/EsgEpdJ4Lbj4sLaMZWA==",
       "cpu": [
         "x64"
       ],
@@ -2717,9 +2726,10 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "gulp-replace": "1.1.4",
     "gulp-sass": "5.1.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "8.4.45",
+    "postcss": "8.4.47",
     "postcss-csso": "6.0.1",
-    "sass-embedded": "1.78.0"
+    "sass-embedded": "1.79.4"
   },
   "devDependencies": {
-    "@uswds/uswds": "^3.8.2",
+    "@uswds/uswds": "^3.9.0",
     "uswds": "^2.14.0"
   },
   "overrides": {


### PR DESCRIPTION
# Summary

POAM dependency updates for October 2024.

## Vulnerabilities

No changes in vulnerabilities

```node
found 0 vulnerabilities
```

## Major changes

- Updated to latest USWDS version

## Dependency updates

| Dependency name | Old version | New version |
| --- | --- | --- |
| @uswds/uswds | ^3.8.2 | ^3.9.0 |
| postcss | 8.4.45 | 8.4.47 |
| sass-embedded | 1.78.0 | 1.79.4 |

## Testing instructions

1. Install this branch on site
    - On Site's `main` branch, run: 
      ```bash
      npm install "https://github.com/uswds/uswds-compile/tree/cm-POAM-oct-24" --save
      ```
2. Run gulp build scripts and ensure compile runs as expected without error.
3. Ensure no regressions when package is used to compile site




