### PR TITLE
USWDS-Compile - POAM: February '25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "gulp-replace": "1.1.4",
         "gulp-sass": "5.1.0",
         "gulp-svgstore": "9.0.0",
-        "postcss": "8.5.1",
+        "postcss": "8.5.2",
         "postcss-csso": "6.0.1",
         "sass-embedded": "1.83.4"
       },
@@ -2244,9 +2244,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-replace": "1.1.4",
     "gulp-sass": "5.1.0",
     "gulp-svgstore": "9.0.0",
-    "postcss": "8.5.1",
+    "postcss": "8.5.2",
     "postcss-csso": "6.0.1",
     "sass-embedded": "1.83.4"
   },


### PR DESCRIPTION
# Summary

POAM dependency updates for February, 2025.

## Related issue

[USWDS-Team - POAM: February 2025](https://github.com/uswds/uswds-team/issues/477)

## Vulnerabilities

No changes in vulnerabilities

```node
found 0 vulnerabilities
```
## Dependency updates

| Dependency Name | Old Version | New Version |
| --- | --- | --- |
| postcss | 8.5.1 | 8.5.2 |

## Testing instructions

1. Install this branch on site
    - On Site's `main` branch, run: 
      ```bash
      npm install "https://github.com/uswds/uswds-compile/tree/cb-poam-feb-25" --save
      ```
2. Run gulp build scripts and ensure compile runs as expected without error.

3. Ensure no regressions when package is used to compile site