### PR TITLE
Check for existence of web component path before trying to copy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,9 +137,12 @@ const copy = {
     );
   },
   components() {
+    if (!fs.existsSync(getSrcFrom("components"))) return Promise.resolve();
     log(
       colors.blue,
-      `Copy USWDS compiled Web Components: ${getSrcFrom("components")} →  ${paths.dist.js}`
+      `Copy USWDS compiled Web Components: ${getSrcFrom("components")} →  ${
+        paths.dist.components
+      }`
     );
     return src(`${getSrcFrom("components")}/**/**`.replace("//", "/")).pipe(
       dest(paths.dist.components)


### PR DESCRIPTION
The new task for copying web components will fail when that directory doesn't exist. This checks for the existence of that directory before trying to copy it.

Fixes #156 