### PR TITLE
USWDS Compile: Hotfix v1.3.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,9 +137,12 @@ const copy = {
     );
   },
   components() {
+    if (!fs.existsSync(getSrcFrom("components"))) return Promise.resolve();
     log(
       colors.blue,
-      `Copy USWDS compiled Web Components: ${getSrcFrom("components")} →  ${paths.dist.js}`
+      `Copy USWDS compiled Web Components: ${getSrcFrom("components")} →  ${
+        paths.dist.components
+      }`
     );
     return src(`${getSrcFrom("components")}/**/**`.replace("//", "/")).pipe(
       dest(paths.dist.components)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uswds/compile",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uswds/compile",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "autoprefixer": "10.4.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uswds/compile",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uswds/compile",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "autoprefixer": "10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswds/compile",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Gulp-based compiler for USWDS Sass",
   "main": "gulpfile.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswds/compile",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A Gulp-based compiler for USWDS Sass",
   "main": "gulpfile.js",
   "scripts": {


### PR DESCRIPTION
# What's New in this Release

This release just contains a bugfix in the copy assets task when running against current versions of USWDS.

`0` vulnerabilities using npm audit.

Release TGZ SHA-256 hash: `4bc31a3fcae3c51dac860a14b0f8214b2927b884cba199bbf1266220a6fa4a38`