### PR TITLE
USWDS-Compile: Add automated release workflow for tagged npm publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Update npm version
         run: npm install -g npm@latest # OIDC requires npm v11.5.1 or later
       - run: npm ci
-      - run: npm run build --if-present
-      # - run: npm run test
       - run: npm publish
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # pin v2.6.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,13 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin v6.3.0
@@ -20,9 +21,9 @@ jobs:
       - name: Update npm version
         run: npm install -g npm@latest # OIDC requires npm v11.5.1 or later
       - run: npm ci
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run build --if-present
+      # - run: npm run test
+      - run: npm publish
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # pin v2.6.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Publish Package to npmjs
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # pin v6.3.0
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update npm version
+        run: npm install -g npm@latest # OIDC requires npm v11.5.1 or later
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # pin v2.6.1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

Added a GitHub Actions workflow that publishes tagged releases to npm and automatically creates a GitHub Release.

## Related issue

References #171 

## Problem statement

Releasing new package versions required a manual publish process, which made releases slower and more error-prone. There was also no automated release artifact creation tied to version tags.

## Solution

Introduced a workflow that runs on version tags matching `v*.*.*`, installs dependencies, publishes the package to npm using provenance, and then creates a GitHub Release with generated notes.

This approach keeps release steps consistent and reduces the chance of missing a publish step during release day.

## Testing and review

Right now, just verify valid syntax. This will need to get merged in order to test its proper function. Ultimate acceptance criteria will be:

- npm publish runs successfully with provenance enabled
- the package is published only on tagged releases
- a GitHub Release is created with generated notes
 
...but that is something that can only be verified once this is in a merged branch.