### PR TITLE
USWDS-Compile: Add dependency audit and package artifact generation to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,18 @@ jobs:
       - name: Update npm version
         run: npm install -g npm@latest # OIDC requires npm v11.5.1 or later
       - run: npm ci
-      - run: npm publish
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # pin v2.6.1
+      - name: Audit dependencies
+        run: |
+          audit_output=$(npm audit --json || true)
+          vuln_count=$(node -e "const fs=require('fs'); const input=fs.readFileSync(0,'utf8'); const data=JSON.parse(input || '{}'); const total=(data.metadata && data.metadata.vulnerabilities && Object.values(data.metadata.vulnerabilities).reduce((sum,v)=>sum+(Number(v)||0),0)) || 0; console.log(total);" <<< "$audit_output")
+          echo "Vulnerabilities: $vuln_count"
+      - name: Pack package
+        run: npm pack
+      - name: Upload pack artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin v7.0.0
         with:
-          generate_release_notes: true
+          name: npm-pack
+          path: "*.tgz"
+      - run: npm publish
+        if: ${{ !env.ACT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,20 @@ jobs:
       - name: Update npm version
         run: npm install -g npm@latest # OIDC requires npm v11.5.1 or later
       - run: npm ci
-      - name: Audit dependencies
+      - name: Check for vulnerabilities
         run: |
-          audit_output=$(npm audit --json || true)
-          vuln_count=$(node -e "const fs=require('fs'); const input=fs.readFileSync(0,'utf8'); const data=JSON.parse(input || '{}'); const total=(data.metadata && data.metadata.vulnerabilities && Object.values(data.metadata.vulnerabilities).reduce((sum,v)=>sum+(Number(v)||0),0)) || 0; console.log(total);" <<< "$audit_output")
-          echo "Vulnerabilities: $vuln_count"
+          # Capture audit result (ignore exit code with || true)
+          AUDIT_RESULT=$(npm audit --json || true)
+          CRITICAL=$(echo $AUDIT_RESULT | jq '.metadata.vulnerabilities.critical // 0')
+          HIGH=$(echo $AUDIT_RESULT | jq '.metadata.vulnerabilities.high // 0')
+          TOTAL=$(echo $AUDIT_RESULT | jq '.metadata.vulnerabilities.total // 0')
+          
+          if [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ]; then
+            echo "Found $CRITICAL critical and $HIGH high severity vulnerabilities"
+            echo "Please review and fix these vulnerabilities"
+            exit 1
+          fi
+          echo "No critical or high severity vulnerabilities found. Total vulnerabilities: $TOTAL"
       - name: Pack package
         run: npm pack
       - name: Upload pack artifact


### PR DESCRIPTION
## Summary

This update added a dependency audit and package packing step to the release workflow before publishing to npm. It also uploaded the generated package archive as a build artifact make it easier to set up a draft of the release on GitHub.

## Related issue

Closes #171 

## Problem statement

The release workflow published directly to npm without first surfacing dependency audit results or preserving the packed package artifact. We were doing those last steps manually and now they are automated.

## Solution

This change updated the GitHub Actions release job to:

- run `npm audit` and report the total vulnerability count,
- generate the npm package archive with `npm pack`,
- upload the resulting `.tgz` file as a workflow artifact,
- and then continue with `npm publish`.

This approach adds lightweight release validation and creates a reusable artifact for verification without changing the publish target or release trigger.

## Testing and review

Manual testing can be done with the GitHub CLI and `act`. 

- https://docs.github.com/en/github-cli/github-cli/about-github-cli
- https://github.com/nektos/gh-act

The test command is 

```bash
gh act -W .github/workflows/release.yml
```