### PR TITLE
Pin dependencies for workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin v6.0.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # pin v4.35.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # pin v4.35.1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # pin v4.35.1


### PR DESCRIPTION
## Summary

Pinned specific SHA versions for the CodeQL GitHub Actions used in the CI workflow to tighten security posture.

## Related issue

[#6601](https://github.com/uswds/uswds/issues/6601)

## Problem statement

The `.github/workflows/codeql.yml` file referenced mutable tags (`@v2`, `@v1`) for the CodeQL actions. The more secure option is to pin these to specific commit hashes so we know exactly which version is running.

## Solution

Replaced the floating tags with pinned commit SHAs for the following actions:
- `actions/checkout` pinned to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
- `github/codeql-action/init` pinned to `c10b8064de6f491fea524254123dbe5e09572f13` (v4.35.1)
- `github/codeql-action/autobuild` pinned to the same SHA as above
- `github/codeql-action/analyze` pinned to the same SHA as above  

This ensures the workflow uses known versions of the actions, providing stability and predictability for future runs.

## Testing and review

- Verified that the workflow runs successfully on a fresh GitHub Actions runner after pinning the versions.
- Confirmed that CodeQL analysis completes without errors.
- Reviewed the pinned SHAs against the released versions to ensure correctness.
