### PR TITLE
Remove IE11 from browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,4 @@
 # Supported browsers
 > 2%
 last 2 versions
-IE 11
 not dead


### PR DESCRIPTION
Removes IE11 from `.browserslistrc` to align the compile tool output with our supported browser strategy: https://designsystem.digital.gov/documentation/developers/#browser-support 